### PR TITLE
Fix CI build: vite/client ambient types; opt actions into Node 24

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,12 @@ on:
     branches-ignore:
       - master
 
+# Opt JS-based actions (checkout, setup-node, ...) into the Node 24 runtime
+# ahead of GitHub's June 2, 2026 cutover. Remove this once we're on action
+# majors that ship with Node 24 natively (checkout/setup-node v5+).
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   lint-and-build:
     runs-on: ubuntu-latest
@@ -14,7 +20,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
           # cache: npm  # re-enable once a package-lock.json is committed
 
       # Use `npm install` until a lockfile is committed; switch to `npm ci` after.

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -18,6 +18,12 @@ concurrency:
   group: pages
   cancel-in-progress: false
 
+# Opt JS-based actions (checkout, setup-node, deploy-pages, ...) into the
+# Node 24 runtime ahead of GitHub's June 2, 2026 cutover. Remove this once
+# we're on action majors that ship with Node 24 natively.
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -26,7 +32,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
           # cache: npm  # re-enable once a package-lock.json is committed
 
       # Use `npm install` until a lockfile is committed; switch to `npm ci` after.

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />


### PR DESCRIPTION
Follow-up to #33 to unblock CI and quiet the Node 20 deprecation warning.

## What

- **`src/vite-env.d.ts`** — adds `/// <reference types="vite/client" />` so the `tsc -b` step (which runs before `vite build` per the new `build` script) can resolve `*.css` and other Vite asset imports. Fixes the failing build:
  > `src/main.tsx#L4 Cannot find module './App.css' or its corresponding type declarations.`
- **`FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true`** at the workflow level on both `.github/workflows/ci.yml` and `.github/workflows/deploy.yml` — opts the still-on-`@v4` JS actions (`checkout`, `setup-node`, `deploy-pages`) into the Node 24 runtime ahead of GitHub's June 2, 2026 cutover. Documented opt-in straight from the deprecation warning.
- **`node-version: 22`** (was `20`) in both workflows — current Node LTS for the npm toolchain step.

## Why this is a separate PR

#33 was already merged when CI surfaced the missing-types error and the Node 20 deprecation warning. Kept this small and focused so the failure-mode and fix are easy to read in isolation.

## Follow-ups not in this PR

- Switch action majors to `@v5` (or whatever ships natively on Node 24) and drop the env-var opt-in.
- Commit a `package-lock.json` and flip `npm install` → `npm ci` plus uncomment `cache: npm` in `setup-node` (there are explicit comments at those lines in both workflows).

https://claude.ai/code/session_01TDMf5QCvZfHQQzTVJ2uRyZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01TDMf5QCvZfHQQzTVJ2uRyZ)_