### PR TITLE
Keyboard hints, win-sequence pause, non-board-hiding end banner

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,12 @@ node_modules/
 dist/
 *.local
 
+# Lock file — npm regenerates it in CI; not tracked in this repo.
+package-lock.json
+
+# TypeScript incremental build cache
+*.tsbuildinfo
+
 # Editor / OS
 .DS_Store
 .idea/

--- a/src/App.css
+++ b/src/App.css
@@ -300,3 +300,102 @@ canvas {
     transition: none;
   }
 }
+
+/* ─────────────────────── keyboard hints toggle ─────────────────────── */
+
+/*
+ * Viewport-fixed pill in the top-right corner. Desktop-only — touch users
+ * don't have a keyboard, so the hint affordance is hidden there.
+ *
+ * Note: positioned in the *viewport*, not the canvas, so it doesn't compete
+ * with the canvas-painted MENU button (which lives at the top-right of the
+ * canvas itself). On a centered canvas with margins, the two are visually
+ * separated by the wrap padding.
+ */
+.kb-toggle {
+  position: fixed;
+  top: 1rem;
+  right: 1rem;
+  z-index: 90;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.45rem 0.8rem;
+  background: rgba(255, 255, 255, 0.92);
+  color: #14213d;
+  border: 1px solid rgba(20, 33, 61, 0.18);
+  border-radius: 999px;
+  font: inherit;
+  font-size: 0.82rem;
+  font-weight: 500;
+  cursor: pointer;
+  box-shadow: 0 2px 10px rgba(0, 0, 0, 0.18);
+  transition: background 0.15s ease, color 0.15s ease,
+              border-color 0.15s ease, transform 0.1s ease;
+}
+
+.kb-toggle:hover {
+  background: #fff;
+  border-color: rgba(20, 33, 61, 0.32);
+}
+
+.kb-toggle:focus-visible {
+  outline: 2px solid #fff;
+  outline-offset: 2px;
+}
+
+.kb-toggle[aria-pressed='true'] {
+  background: #1565c0;
+  color: #fff;
+  border-color: #1565c0;
+}
+
+.kb-toggle-icon {
+  font-size: 1.05em;
+  line-height: 1;
+}
+
+/*
+ * Hide on touch / small screens. Keyboard hints don't apply when there's no
+ * physical keyboard anyway, so removing the toggle entirely is the right move.
+ */
+@media (max-width: 720px), (hover: none) {
+  .kb-toggle {
+    display: none;
+  }
+}
+
+/* ─────────────────────── inline keyboard-hint footers ─────────────────────── */
+
+/*
+ * Small contextual hint appended to a modal when the user has the keyboard
+ * hints toggle on. Inline <kbd>s are styled to look like physical keys.
+ */
+.modal-kb-hint {
+  margin: 1rem 0 0;
+  padding: 0.55rem 0.75rem;
+  background: rgba(21, 101, 192, 0.07);
+  border-radius: 8px;
+  font-size: 0.76rem;
+  line-height: 1.5;
+  color: #5d6b89;
+  text-align: center;
+}
+
+.modal-kb-hint kbd {
+  display: inline-block;
+  min-width: 1.4em;
+  padding: 0.05rem 0.35rem;
+  margin: 0 0.1rem;
+  background: #fff;
+  color: #14213d;
+  border: 1px solid rgba(20, 33, 61, 0.2);
+  border-bottom-width: 2px;
+  border-radius: 4px;
+  font-family: ui-monospace, "SF Mono", Menlo, monospace;
+  font-size: 0.78em;
+  font-weight: 600;
+  line-height: 1.3;
+  text-align: center;
+  vertical-align: 1px;
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -73,7 +73,6 @@ const App = () => {
 
     const ctx = canvas.getContext('2d');
     if (!ctx) {
-      // eslint-disable-next-line no-console
       console.error('2d context unavailable; the game cannot render.');
       return;
     }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,11 +3,17 @@ import { useEffect, useRef } from 'react';
 import { useGameStore } from './store';
 import { COLUMNS, ROWS } from './constants';
 import { computeLayout, type Layout } from './canvas/layout';
-import { cellKey, createAnimState } from './canvas/animations';
+import {
+  cellKey,
+  createAnimState,
+  DROP_DURATION_MS,
+  winSequenceDuration,
+} from './canvas/animations';
 import { paint, paintAttract } from './canvas/scene';
 import { setupInputs } from './canvas/input';
 import { chooseMove } from './ai/engine';
 import { createAttract, resetAttract, stepAttract } from './ai/attractDemo';
+import { KeyboardHintsToggle } from './components/KeyboardHintsToggle';
 import { WelcomeModal } from './components/WelcomeModal';
 import { ResetConfirmModal } from './components/ResetConfirmModal';
 
@@ -108,7 +114,30 @@ const App = () => {
     };
     seedFromBoard();
 
-    // Watch the store for new pieces / overlay transitions.
+    // ── win-sequence driver ──
+    //
+    // When a game ends, the store sets winner/winningPieces/gamePhase='finished'
+    // but DEFERS showOverlay so the user gets to see the winning pieces light
+    // up one by one before the banner appears. We:
+    //
+    //   1. Record `winSequenceStartedAt` offset by DROP_DURATION_MS so the
+    //      highlight doesn't begin until the winning piece has actually
+    //      landed (otherwise it'd be fading to white mid-air).
+    //   2. Schedule revealEndOverlay() to fire DROP + sequence ms later.
+    //
+    // A generation counter discards stale timers if the game is reset before
+    // the sequence completes (e.g. quickly through the MENU button).
+    let endRevealTimer: number | null = null;
+    let endRevealGen = 0;
+
+    const cancelPendingReveal = () => {
+      if (endRevealTimer !== null) {
+        window.clearTimeout(endRevealTimer);
+        endRevealTimer = null;
+      }
+    };
+
+    // Watch the store for new pieces / overlay transitions / game-end transitions.
     const unsubscribeAnim = useGameStore.subscribe((state, prev) => {
       const now = performance.now();
 
@@ -125,6 +154,27 @@ const App = () => {
             }
           }
         }
+      }
+
+      // Game just ended: kick off the win sequence + schedule the banner.
+      if (state.gamePhase === 'finished' && prev.gamePhase === 'playing') {
+        anim.winSequenceStartedAt = now + DROP_DURATION_MS;
+        const totalDelay =
+          DROP_DURATION_MS + winSequenceDuration(state.winningPieces.length);
+        const myGen = ++endRevealGen;
+        cancelPendingReveal();
+        endRevealTimer = window.setTimeout(() => {
+          endRevealTimer = null;
+          if (myGen !== endRevealGen) return;
+          useGameStore.getState().revealEndOverlay();
+        }, totalDelay);
+      }
+
+      // Game restarted or returned to setup: scrub the win sequence.
+      if (state.gamePhase !== 'finished' && prev.gamePhase === 'finished') {
+        anim.winSequenceStartedAt = null;
+        ++endRevealGen;
+        cancelPendingReveal();
       }
 
       if (state.showOverlay && !prev.showOverlay) {
@@ -284,6 +334,7 @@ const App = () => {
       unsubscribeAi();
       unsubscribePhase();
       cancelPendingAi();
+      cancelPendingReveal();
       stopAttract();
     };
   }, []);
@@ -294,10 +345,11 @@ const App = () => {
 
   return (
     <div className="App">
+      <KeyboardHintsToggle />
       <div ref={wrapRef} className="canvas-wrap">
         <canvas ref={canvasRef} aria-label="Connect 4 game board" role="img" />
         {/*
-          Visually-hidden Reset button. The visible Reset is canvas-painted;
+          Visually-hidden Menu button. The visible button is canvas-painted;
           this one exists purely so screen-reader / keyboard-only users can
           still finish a game. autoFocus pulls focus when the overlay opens.
         */}

--- a/src/canvas/animations.ts
+++ b/src/canvas/animations.ts
@@ -13,6 +13,12 @@ export type AnimState = {
   menuHovered: boolean;
   /** performance.now() when the win/draw overlay first appeared, or null. */
   overlayShownAt: number | null;
+  /**
+   * performance.now() when the game-end sequence started (winning move was
+   * played, or the board filled into a draw). Drives the staggered per-piece
+   * highlight that runs BEFORE the overlay banner is revealed.
+   */
+  winSequenceStartedAt: number | null;
 };
 
 export const createAnimState = (): AnimState => ({
@@ -21,6 +27,7 @@ export const createAnimState = (): AnimState => ({
   resetHovered: false,
   menuHovered: false,
   overlayShownAt: null,
+  winSequenceStartedAt: null,
 });
 
 export const cellKey = (col: number, row: number): string => `${col},${row}`;
@@ -66,10 +73,55 @@ export const easeOutCubic = (t: number): number => {
 // ───────────────────────── durations ─────────────────────────
 
 export const DROP_DURATION_MS = 500;
-export const OVERLAY_BACKDROP_MS = 200;
 export const OVERLAY_CARD_MS = 320;
 /** One full pulse cycle of a winning piece. */
 export const WIN_PULSE_PERIOD_MS = 1400;
+
+/**
+ * Game-end "savor the moment" timing. When the winning move lands we want to
+ * let the player see the result before the menu banner appears:
+ *
+ *   1. Winning pieces light up one by one (`WIN_HIGHLIGHT_STAGGER_MS` apart),
+ *      each piece fading from its normal color to white over
+ *      `WIN_HIGHLIGHT_FADE_MS`.
+ *   2. After the last piece has finished fading, we hold the position for
+ *      `WIN_HIGHLIGHT_HOLD_MS` so the result sinks in.
+ *   3. Then the top banner with the result + Menu button fades in.
+ *
+ * For a draw there's nothing to highlight, so step 1 collapses and we just
+ * use the hold delay before showing the banner.
+ */
+export const WIN_HIGHLIGHT_STAGGER_MS = 180;
+export const WIN_HIGHLIGHT_FADE_MS = 220;
+export const WIN_HIGHLIGHT_HOLD_MS = 900;
+
+/**
+ * Total time between a game ending and the menu banner appearing. For wins,
+ * accounts for the per-piece stagger + fade + hold; for draws just the hold.
+ */
+export const winSequenceDuration = (numWinningPieces: number): number => {
+  if (numWinningPieces <= 0) return WIN_HIGHLIGHT_HOLD_MS;
+  const lastPieceStartsAt = (numWinningPieces - 1) * WIN_HIGHLIGHT_STAGGER_MS;
+  return lastPieceStartsAt + WIN_HIGHLIGHT_FADE_MS + WIN_HIGHLIGHT_HOLD_MS;
+};
+
+/**
+ * Per-piece progress (0..1) for the staggered win highlight. Returns 1 if
+ * the sequence hasn't started yet (i.e. game is in progress and the piece
+ * is just a regular piece — no winner status). Pieces highlight in the
+ * order they appear in the winningPieces array.
+ */
+export const winPieceHighlightProgress = (
+  anim: AnimState,
+  winnerIndex: number,
+  now: number,
+): number => {
+  if (anim.winSequenceStartedAt === null) return 0;
+  const elapsed = now - anim.winSequenceStartedAt - winnerIndex * WIN_HIGHLIGHT_STAGGER_MS;
+  if (elapsed <= 0) return 0;
+  if (elapsed >= WIN_HIGHLIGHT_FADE_MS) return 1;
+  return easeOutCubic(elapsed / WIN_HIGHLIGHT_FADE_MS);
+};
 
 // ───────────────────────── computed values ─────────────────────────
 
@@ -101,15 +153,6 @@ export const winPulseRing = (
     radiusFactor: 1 + phase * 0.6, // 1.0 → 1.6× cell radius
     alpha: 0.55 * (1 - phase),
   };
-};
-
-/** Backdrop opacity 0..1 based on overlay start time. */
-export const overlayBackdropAlpha = (
-  anim: AnimState,
-  now: number,
-): number => {
-  if (anim.overlayShownAt === null) return 0;
-  return easeOutCubic((now - anim.overlayShownAt) / OVERLAY_BACKDROP_MS) * 0.4;
 };
 
 /** Card progress 0..1 (used for scale + opacity of the win/draw card). */

--- a/src/canvas/layout.ts
+++ b/src/canvas/layout.ts
@@ -109,17 +109,22 @@ export const computeLayout = (width: number, height: number): Layout => {
   // metric. The container's CSS aspect-ratio is what really keeps things sane.
   void finalScale;
 
-  // ───── overlay ─────
-  const overlayCardWidth = Math.min(width * 0.72, 360 * scale);
-  const overlayCardHeight = 160 * scale;
-  const overlayCardX = (width - overlayCardWidth) / 2;
-  const overlayCardY = (height - overlayCardHeight) / 2;
-  const overlayCardRadius = 14 * scale;
+  // ───── end-game banner ─────
+  //
+  // Replaces the previous board-covering card. The banner now occupies the
+  // same vertical band as the clocks (top of canvas) so the board stays
+  // fully visible during the end-of-game pause and the menu prompt.
+  const overlayCardWidth = clocksTotalWidth;
+  const overlayCardHeight = clocksCardHeight;
+  const overlayCardX = clocksLeft;
+  const overlayCardY = clocksTop;
+  const overlayCardRadius = 12 * scale;
 
-  const buttonWidth = 140 * scale;
-  const buttonHeight = 42 * scale;
-  const buttonX = overlayCardX + (overlayCardWidth - buttonWidth) / 2;
-  const buttonY = overlayCardY + overlayCardHeight - buttonHeight - 18 * scale;
+  // Menu button sits inside the banner on the right edge.
+  const buttonWidth = 100 * scale;
+  const buttonHeight = 38 * scale;
+  const buttonX = overlayCardX + overlayCardWidth - buttonWidth - 14 * scale;
+  const buttonY = overlayCardY + (overlayCardHeight - buttonHeight) / 2;
   const buttonRadius = 8 * scale;
 
   // ───── in-game menu button (top-right) ─────
@@ -166,7 +171,7 @@ export const computeLayout = (width: number, height: number): Layout => {
         height: overlayCardHeight,
         radius: overlayCardRadius,
       },
-      messageY: overlayCardY + 56 * scale,
+      messageY: overlayCardY + overlayCardHeight / 2,
       button: {
         x: buttonX,
         y: buttonY,

--- a/src/canvas/scene.ts
+++ b/src/canvas/scene.ts
@@ -136,13 +136,6 @@ const drawBackground = (
 const dropStartY = (layout: Layout): number =>
   layout.board.y - layout.cell.size * 1.5;
 
-const isWinningPiece = (
-  winningPieces: ReadonlyArray<WinningPiece>,
-  col: number,
-  row: number,
-): boolean =>
-  winningPieces.some((p) => p.column === col && p.row === row);
-
 /**
  * Paint a soft dark vignette at each cell position. Drawn between the canvas
  * background and the pieces so:

--- a/src/canvas/scene.ts
+++ b/src/canvas/scene.ts
@@ -7,8 +7,8 @@ import {
 import {
   type AnimState,
   dropProgress,
-  overlayBackdropAlpha,
   overlayCardProgress,
+  winPieceHighlightProgress,
   winPulseRing,
   winPulseScale,
 } from './animations';
@@ -52,9 +52,6 @@ const C = {
   // suggest the rim of a slot — like a millimeter of bevel.
   holeRim: 'rgba(140, 90, 0, 0.55)',
 
-  // Thin lines between columns. Very low contrast — your eye reads them as
-  // "the board has columns" without making them feel ruled.
-  columnDivider: 'rgba(100, 60, 0, 0.18)',
   // Highlight stroke along the top arch — fakes a light coming from above.
   topArchHighlight: 'rgba(255, 255, 255, 0.28)',
 
@@ -183,9 +180,22 @@ const drawHoleBackShadows = (
   }
 };
 
+/** Find the position of (col,row) inside the winning-pieces array, or -1. */
+const winnerIndexOf = (
+  winningPieces: ReadonlyArray<WinningPiece>,
+  col: number,
+  row: number,
+): number => winningPieces.findIndex((p) => p.column === col && p.row === row);
+
 /**
  * Draw all pieces for the given board. Board-agnostic so the attract path can
  * paint a separate self-play game without going through the store.
+ *
+ * Winning pieces are highlighted with a staggered fade-to-white based on
+ * `anim.winSequenceStartedAt`. Each piece's highlight progress is computed
+ * from its index in `winningPieces`, so pieces light up *in array order*.
+ * The pulse ring + winPulseScale only kick in once a given piece is fully
+ * highlighted (progress >= 1) AND its drop animation has finished.
  */
 const drawPiecesForBoard = (
   ctx: CanvasRenderingContext2D,
@@ -203,13 +213,19 @@ const drawPiecesForBoard = (
       if (cellValue === 0) continue;
 
       const finalCenter = cellCenter(layout, col, row);
-      const progress = dropProgress(anim, col, row, now);
-      const y = startY + (finalCenter.y - startY) * progress;
-      const isWinner = isWinningPiece(winningPieces, col, row);
+      const dropP = dropProgress(anim, col, row, now);
+      const y = startY + (finalCenter.y - startY) * dropP;
 
-      // Draw the pulse ring under the piece while it pulses (only after the
-      // drop has finished, otherwise it looks odd attached to a falling piece).
-      if (isWinner && progress >= 1) {
+      const winnerIdx = winnerIndexOf(winningPieces, col, row);
+      const isWinner = winnerIdx >= 0;
+      const highlightP = isWinner
+        ? winPieceHighlightProgress(anim, winnerIdx, now)
+        : 0;
+      const fullyHighlighted = isWinner && highlightP >= 1 && dropP >= 1;
+
+      // Pulse ring under fully-highlighted pieces. Skipped while the piece
+      // is still fading in or still in mid-drop.
+      if (fullyHighlighted) {
         const ring = winPulseRing(now);
         ctx.save();
         ctx.globalAlpha = ring.alpha;
@@ -225,16 +241,16 @@ const drawPiecesForBoard = (
         ctx.restore();
       }
 
-      const scale = isWinner && progress >= 1 ? winPulseScale(now) : 1;
+      const scale = fullyHighlighted ? winPulseScale(now) : 1;
       const radius = layout.cell.pieceRadius * scale;
-      const fill = isWinner ? C.pieceWinner : colorFor(cellValue);
+      const fill = colorFor(cellValue);
 
-      // ── piece body ──
+      // ── normal-color body ──
       //
-      // Three-stop radial gradient: a near-white core (off-center, upper-left
-      // light source), the piece's soft tone in the middle, then the full
-      // saturated color at the rim. The wider middle stop is what reads as
-      // "glossy plastic" rather than "flat circle".
+      // Three-stop radial gradient with an off-center light source — reads as
+      // glossy plastic rather than a flat circle. Always drawn (even for
+      // winners) and then overlaid by the white winner gradient at alpha =
+      // highlightP for the staggered fade-in.
       const gradient = ctx.createRadialGradient(
         finalCenter.x - radius * 0.35,
         y - radius * 0.35,
@@ -243,39 +259,60 @@ const drawPiecesForBoard = (
         y,
         radius,
       );
-      if (isWinner) {
-        gradient.addColorStop(0, '#ffffff');
-        gradient.addColorStop(0.75, '#f5f5f5');
-        gradient.addColorStop(1, '#d8d8d8');
-      } else {
-        gradient.addColorStop(0, softColorFor(cellValue));
-        gradient.addColorStop(0.6, fill);
-        // A hair darker than `fill` at the very rim gives the piece a sense
-        // of curving away from the light.
-        gradient.addColorStop(1, fill);
-      }
+      gradient.addColorStop(0, softColorFor(cellValue));
+      gradient.addColorStop(0.6, fill);
+      gradient.addColorStop(1, fill);
+
       ctx.fillStyle = gradient;
       circlePath(ctx, finalCenter.x, y, radius);
       ctx.fill();
 
+      // ── winner overlay (alpha = highlightP) ──
+      //
+      // Cross-fades from the normal-color body to a white-gloss body. At
+      // progress 0 the piece looks normal; at 1 it's fully white. The drop
+      // delay in App.tsx ensures highlightP stays at 0 until the winning
+      // piece has finished falling.
+      if (highlightP > 0) {
+        const winnerGradient = ctx.createRadialGradient(
+          finalCenter.x - radius * 0.35,
+          y - radius * 0.35,
+          radius * 0.05,
+          finalCenter.x,
+          y,
+          radius,
+        );
+        winnerGradient.addColorStop(0, '#ffffff');
+        winnerGradient.addColorStop(0.75, '#f5f5f5');
+        winnerGradient.addColorStop(1, '#d8d8d8');
+
+        ctx.save();
+        ctx.globalAlpha = highlightP;
+        ctx.fillStyle = winnerGradient;
+        circlePath(ctx, finalCenter.x, y, radius);
+        ctx.fill();
+        ctx.restore();
+      }
+
       // ── emboss ring ──
       //
-      // A 1px-ish darker stroke around the edge mimics the moulded lip on
-      // real plastic chips and crisply separates the piece from the cell
-      // rim. Only applied to non-winner pieces; winners read better with the
-      // pulse ring providing their outline.
-      if (!isWinner) {
+      // Darker stroke around the edge mimics the moulded lip on plastic
+      // chips. Fades out as the piece highlights — winners read better
+      // with just the pulse ring outline.
+      if (highlightP < 1) {
+        ctx.save();
+        ctx.globalAlpha = 1 - highlightP;
         ctx.lineWidth = Math.max(1, 1.2 * layout.scale);
         ctx.strokeStyle = C.pieceEmboss;
         circlePath(ctx, finalCenter.x, y, radius - ctx.lineWidth / 2);
         ctx.stroke();
+        ctx.restore();
       }
 
       // ── specular highlight ──
       //
-      // Small bright ellipse offset toward the top-left. Tints over the
-      // gradient core to push the "wet plastic" feeling. Tilted ~30° so it
-      // doesn't look like a perfectly horizontal painter's blob.
+      // Small bright tilted ellipse near the top-left. Keeps the glossy
+      // look on both red/black and the post-highlight white state.
       ctx.save();
       ctx.translate(finalCenter.x - radius * 0.32, y - radius * 0.42);
       ctx.rotate(-Math.PI / 6);
@@ -397,36 +434,6 @@ const drawHoleRims = (
       ctx.stroke();
     }
   }
-};
-
-/**
- * Thin vertical column dividers, clipped to the yellow region (so they don't
- * paint over the holes or the back of the cells). They're nearly invisible by
- * design — only the eye-tracking sense of "ah, columns" should register.
- */
-const drawColumnDividers = (
-  ctx: CanvasRenderingContext2D,
-  layout: Layout,
-): void => {
-  const { board, cell, scale } = layout;
-
-  // Clip to (board outer shape) ∖ (holes). Even-odd matches the same fill
-  // rule the board uses, so what we end up with is "yellow face only".
-  ctx.save();
-  buildBoardSilhouette(ctx, layout);
-  appendHoleSubpaths(ctx, layout);
-  ctx.clip('evenodd');
-
-  ctx.strokeStyle = C.columnDivider;
-  ctx.lineWidth = Math.max(1, 1.5 * scale);
-  for (let col = 1; col < COLUMNS; col++) {
-    const x = board.x + board.padding + col * cell.size;
-    ctx.beginPath();
-    ctx.moveTo(x, board.bodyTop - board.topArchHeight * 0.4);
-    ctx.lineTo(x, board.bodyTop + board.bodyHeight + board.bottomArchHeight * 0.25);
-    ctx.stroke();
-  }
-  ctx.restore();
 };
 
 /**
@@ -708,6 +715,31 @@ const drawThinkingIndicator = (
   ctx.restore();
 };
 
+// ───────────────────────── column key hints ─────────────────────────
+
+/**
+ * Paint the digit (1-7) above each column when keyboard hints are on, so
+ * players know which number key drops a piece into which column. Sits in the
+ * narrow gap between the clocks band and the board's top arch.
+ */
+const drawColumnKeyHints = (
+  ctx: CanvasRenderingContext2D,
+  layout: Layout,
+): void => {
+  const { board, cell, scale } = layout;
+
+  // Position: just above the top arch of the board.
+  const labelY = board.y - 6 * scale;
+  ctx.fillStyle = 'rgba(255, 255, 255, 0.78)';
+  ctx.font = `bold ${13 * scale}px system-ui, -apple-system, sans-serif`;
+  ctx.textAlign = 'center';
+  ctx.textBaseline = 'bottom';
+  for (let col = 0; col < COLUMNS; col++) {
+    const x = board.x + board.padding + (col + 0.5) * cell.size;
+    ctx.fillText(String(col + 1), x, labelY);
+  }
+};
+
 // ───────────────────────── board title ─────────────────────────
 
 const drawBoardTitle = (
@@ -725,9 +757,17 @@ const drawBoardTitle = (
   ctx.fillText('CONNECT4', cx, cy);
 };
 
-// ───────────────────────── overlay ─────────────────────────
+// ───────────────────────── end-of-game banner ─────────────────────────
 
-const drawOverlay = (
+/**
+ * Slim banner painted in the clocks band when a game is over. Replaces the
+ * old centered card so the board stays fully visible behind it (winning
+ * pieces in particular). Contains the result on the left and a Menu button
+ * on the right; no canvas-wide dim.
+ *
+ * Animates in via a fade + slight scale, reusing `overlayCardProgress`.
+ */
+const drawEndBanner = (
   ctx: CanvasRenderingContext2D,
   layout: Layout,
   state: GameState,
@@ -736,58 +776,56 @@ const drawOverlay = (
 ): void => {
   if (!state.showOverlay) return;
 
-  const backdropAlpha = overlayBackdropAlpha(anim, now);
   const cardProgress = overlayCardProgress(anim, now);
-
-  // Full-canvas backdrop.
-  ctx.save();
-  ctx.globalAlpha = backdropAlpha;
-  ctx.fillStyle = '#000000';
-  ctx.fillRect(0, 0, layout.width, layout.height);
-  ctx.restore();
-
-  // Card — scaled slightly up, fading in.
   const card = layout.overlay.card;
-  const scale = 0.94 + 0.06 * cardProgress;
   const cardCx = card.x + card.width / 2;
   const cardCy = card.y + card.height / 2;
 
+  // Subtle fade-in + scale-up. No backdrop dim — we want the board
+  // (especially the winning pieces) to stay readable underneath.
+  const scaleAnim = 0.94 + 0.06 * cardProgress;
   ctx.save();
   ctx.globalAlpha = cardProgress;
   ctx.translate(cardCx, cardCy);
-  ctx.scale(scale, scale);
+  ctx.scale(scaleAnim, scaleAnim);
   ctx.translate(-cardCx, -cardCy);
 
-  // Card body (cream) — single rounded rect with a drop shadow.
+  // Banner body with a soft drop-shadow so it lifts off the canvas.
   ctx.save();
   ctx.shadowColor = C.cardShadow;
-  ctx.shadowBlur = 24 * layout.scale;
-  ctx.shadowOffsetY = 8 * layout.scale;
+  ctx.shadowBlur = 18 * layout.scale;
+  ctx.shadowOffsetY = 4 * layout.scale;
   roundedRectPath(ctx, card.x, card.y, card.width, card.height, card.radius);
   ctx.fillStyle = C.cardBg;
   ctx.fill();
   ctx.restore();
 
-  // Blue top half — fill a rectangle clipped to the card's rounded shape so
-  // the top corners stay rounded while the bottom edge is a clean divider.
-  ctx.save();
-  roundedRectPath(ctx, card.x, card.y, card.width, card.height, card.radius);
-  ctx.clip();
-  ctx.fillStyle = C.boardBlue;
-  ctx.fillRect(card.x, card.y, card.width, card.height / 2);
-  ctx.restore();
+  // Left side: colored accent stripe in the winner's color (or neutral grey
+  // for a draw) — quick visual anchor for who won.
+  const stripeWidth = 6 * layout.scale;
+  ctx.fillStyle = state.isDraw
+    ? '#8b9ab0'
+    : state.winner === 1
+      ? C.pieceRed
+      : C.pieceBlack;
+  ctx.fillRect(
+    card.x,
+    card.y + 10 * layout.scale,
+    stripeWidth,
+    card.height - 20 * layout.scale,
+  );
 
-  // Message text.
+  // Message text — left-aligned next to the stripe.
   const message = state.isDraw
     ? "It's a draw"
     : `Player ${state.winner ?? state.currentPlayer} wins!`;
-  ctx.fillStyle = C.textOnBlue;
-  ctx.textAlign = 'center';
+  ctx.fillStyle = C.textOnCard;
+  ctx.textAlign = 'left';
   ctx.textBaseline = 'middle';
-  ctx.font = `bold ${24 * layout.scale}px system-ui, -apple-system, sans-serif`;
-  ctx.fillText(message, cardCx, card.y + card.height * 0.25);
+  ctx.font = `bold ${22 * layout.scale}px system-ui, -apple-system, sans-serif`;
+  ctx.fillText(message, card.x + stripeWidth + 16 * layout.scale, cardCy);
 
-  // Reset button.
+  // Menu button on the right.
   const btn = layout.overlay.button;
   const hovered = anim.resetHovered;
 
@@ -799,9 +837,10 @@ const drawOverlay = (
     ctx.strokeStyle = C.boardBlue;
     ctx.stroke();
   }
-
   ctx.fillStyle = hovered ? C.boardBlue : C.textOnBlue;
-  ctx.font = `${16 * layout.scale}px system-ui, sans-serif`;
+  ctx.textAlign = 'center';
+  ctx.textBaseline = 'middle';
+  ctx.font = `${15 * layout.scale}px system-ui, sans-serif`;
   ctx.fillText('Menu', btn.x + btn.width / 2, btn.y + btn.height / 2 + 1);
 
   ctx.restore();
@@ -838,7 +877,6 @@ export const paintAttract = (
   drawBoardFeet(ctx, layout);
   drawBoardWithHoles(ctx, layout);
   drawHoleRims(ctx, layout);
-  drawColumnDividers(ctx, layout);
   drawTopArchHighlight(ctx, layout);
   drawBoardTitle(ctx, layout);
 };
@@ -863,14 +901,18 @@ export const paint = (
     drawBoardFeet(ctx, layout);
     drawBoardWithHoles(ctx, layout);
     drawHoleRims(ctx, layout);
-    drawColumnDividers(ctx, layout);
     drawTopArchHighlight(ctx, layout);
     drawBoardTitle(ctx, layout);
     return;
   }
 
-  // 2. Clocks or minimal turn indicator, depending on config.
-  if (state.timersEnabled) {
+  // 2. Top band: clocks / turn indicator OR the end-of-game banner. The
+  //    banner only takes over once `showOverlay` is set (after the win
+  //    sequence completes); during the sequence pause the clocks stay visible
+  //    so the player sees the final times alongside the highlight animation.
+  if (state.showOverlay) {
+    // Don't paint clocks during the banner — banner sits in their space.
+  } else if (state.timersEnabled) {
     drawClocks(ctx, layout, state);
   } else {
     drawTurnIndicator(ctx, layout, state);
@@ -884,7 +926,8 @@ export const paint = (
 
   // 4. Pieces. Mid-drop pieces appear above the board area; they remain
   //    visible since the yellow face in step 6 only covers the rectangle
-  //    below + cuts holes through which settled pieces show.
+  //    below + cuts holes through which settled pieces show. Winning pieces
+  //    fade to white in staggered order based on anim.winSequenceStartedAt.
   drawPiecesForBoard(ctx, layout, state.gameBoard, state.winningPieces, anim, now);
 
   // 5. Support feet — drawn before the yellow face so the bottom-arch
@@ -895,32 +938,40 @@ export const paint = (
   //    the holes; everything else is covered by the yellow gradient.
   drawBoardWithHoles(ctx, layout);
 
-  // 7. Hole rims, column dividers, top-arch highlight — micro-details that
-  //    only register as "the board has texture" rather than as visible
-  //    elements. All clipped/positioned so they sit on the yellow.
+  // 7. Hole rims + top-arch highlight — micro-details that read as "the
+  //    board has texture" rather than as visible elements. All clipped or
+  //    positioned to sit on the yellow.
   drawHoleRims(ctx, layout);
-  drawColumnDividers(ctx, layout);
   drawTopArchHighlight(ctx, layout);
 
-  // 8. Hover indicator + ghost piece. Drawn after the board so the ghost
-  //    appears INSIDE the appropriate hole and the column tint sits on top
-  //    of the yellow band.
-  drawHover(ctx, layout, state, anim);
+  // 8. Column key hints — "1" through "7" above each column. Shown only
+  //    while the game is live (a true hint applies only when input matters)
+  //    and the user has the keyboard-hints toggle on.
+  if (state.keyboardHintsVisible && state.gamePhase === 'playing' && !state.showOverlay) {
+    drawColumnKeyHints(ctx, layout);
+  }
 
-  // 9. "CONNECT4" title.
+  // 9. Hover indicator + ghost piece. Drawn after the board so the ghost
+  //    appears INSIDE the appropriate hole and the column tint sits on top
+  //    of the yellow band. Suppressed during the end-banner / win sequence.
+  if (!state.showOverlay) {
+    drawHover(ctx, layout, state, anim);
+  }
+
+  // 10. "CONNECT4" title.
   drawBoardTitle(ctx, layout);
 
-  // 10. In-game MENU button (top-right). Hidden once the win/draw overlay
-  //     is up — that overlay has its own Menu button.
-  if (!state.showOverlay) {
+  // 11. In-game MENU button (top-right). Hidden once the win/draw banner
+  //     is up — that banner has its own Menu button.
+  if (!state.showOverlay && state.gamePhase === 'playing') {
     drawMenuButton(ctx, layout, anim);
   }
 
-  // 11. AI "thinking" pulse, layered above the board but below the overlay.
+  // 12. AI "thinking" pulse, layered above the board but below the banner.
   if (state.aiThinking) {
     drawThinkingIndicator(ctx, layout, now);
   }
 
-  // 12. End-of-game overlay.
-  drawOverlay(ctx, layout, state, anim, now);
+  // 13. End-of-game banner. Sits in the clocks band; doesn't cover the board.
+  drawEndBanner(ctx, layout, state, anim, now);
 };

--- a/src/components/KeyboardHintsToggle.tsx
+++ b/src/components/KeyboardHintsToggle.tsx
@@ -1,0 +1,35 @@
+import { useGameStore } from '../store';
+
+/**
+ * Viewport-fixed toggle that controls whether keyboard-shortcut hints are
+ * shown throughout the app. Hidden on touch / small screens via CSS — those
+ * users don't have a keyboard to receive the hints anyway.
+ *
+ * Affects:
+ *   - Canvas: paints "1"-"7" above each column when on.
+ *   - Welcome modal: shows a hint footer with arrow-key navigation guidance.
+ *   - Reset-confirm modal: shows a hint footer with Enter/Esc guidance.
+ */
+export const KeyboardHintsToggle = () => {
+  const visible = useGameStore((s) => s.keyboardHintsVisible);
+  const toggle = useGameStore((s) => s.toggleKeyboardHints);
+
+  return (
+    <button
+      type="button"
+      className="kb-toggle"
+      onClick={toggle}
+      aria-pressed={visible}
+      aria-label={
+        visible
+          ? 'Hide keyboard controls throughout the app'
+          : 'Show keyboard controls throughout the app'
+      }
+    >
+      <span className="kb-toggle-icon" aria-hidden="true">⌨</span>
+      <span className="kb-toggle-label">
+        {visible ? 'Hide keyboard controls' : 'Show keyboard controls'}
+      </span>
+    </button>
+  );
+};

--- a/src/components/ResetConfirmModal.tsx
+++ b/src/components/ResetConfirmModal.tsx
@@ -10,20 +10,32 @@ import { useGameStore } from '../store';
 export const ResetConfirmModal = () => {
   const cancelResetRequest = useGameStore((s) => s.cancelResetRequest);
   const openSetup = useGameStore((s) => s.openSetup);
+  const keyboardHintsVisible = useGameStore((s) => s.keyboardHintsVisible);
   const cancelButtonRef = useRef<HTMLButtonElement>(null);
+  const confirmButtonRef = useRef<HTMLButtonElement>(null);
 
   // Focus Cancel by default — destructive action is never the default focus.
   useEffect(() => {
     cancelButtonRef.current?.focus();
   }, []);
 
-  // Allow Enter to dismiss when Cancel is focused; Esc is handled globally
-  // in the canvas keydown handler, but we re-handle it here so the modal
-  // works even if focus is inside it.
+  /**
+   * Swap focus between Cancel and Return with arrow keys. Mirrors the modal's
+   * other keyboard affordances — Esc to dismiss, Enter to activate the
+   * focused button.
+   */
   const onKeyDown = (event: React.KeyboardEvent) => {
     if (event.key === 'Escape') {
       event.preventDefault();
       cancelResetRequest();
+      return;
+    }
+    if (event.key === 'ArrowLeft' || event.key === 'ArrowUp') {
+      event.preventDefault();
+      cancelButtonRef.current?.focus();
+    } else if (event.key === 'ArrowRight' || event.key === 'ArrowDown') {
+      event.preventDefault();
+      confirmButtonRef.current?.focus();
     }
   };
 
@@ -54,12 +66,20 @@ export const ResetConfirmModal = () => {
           </button>
           <button
             type="button"
+            ref={confirmButtonRef}
             className="danger-btn"
             onClick={openSetup}
           >
             Return
           </button>
         </div>
+
+        {keyboardHintsVisible && (
+          <p className="modal-kb-hint" role="note">
+            <kbd>←</kbd> <kbd>→</kbd> to swap, <kbd>Enter</kbd> to confirm,{' '}
+            <kbd>Esc</kbd> to cancel.
+          </p>
+        )}
       </div>
     </div>
   );

--- a/src/components/WelcomeModal.tsx
+++ b/src/components/WelcomeModal.tsx
@@ -1,4 +1,11 @@
-import { useEffect, useState, type ReactNode } from 'react';
+import {
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+  type KeyboardEvent,
+  type ReactNode,
+} from 'react';
 
 import { useGameStore } from '../store';
 import type { Difficulty, GameMode, PieceColor } from '../constants';
@@ -9,46 +16,128 @@ import type { Difficulty, GameMode, PieceColor } from '../constants';
  * Form state is local: the player can toggle options without touching the
  * store until they commit by clicking "Play". The fields are pre-filled from
  * the store's last selections so a returning player keeps their preferences.
+ *
+ * Keyboard navigation
+ * -------------------
+ * Each segmented control implements the "roving tabindex" pattern. Within a
+ * group, only the currently-selected pill is tabbable (tabIndex=0); arrow
+ * keys move focus between options *and select them*. Tab moves between
+ * groups + the Play button. This matches the WAI-ARIA radiogroup behavior.
  */
 
-type PillProps = {
-  checked: boolean;
-  onClick: () => void;
-  children: ReactNode;
-  ariaLabel?: string;
+type SegmentedProps<T extends string | boolean> = {
+  legend: string;
+  /** Unique class hook for layout (segmented-2 / segmented-3). */
+  layoutClass: 'segmented-2' | 'segmented-3';
+  /** Ordered list of options with their display label / extra content. */
+  options: ReadonlyArray<{ value: T; render: ReactNode; ariaLabel?: string }>;
+  value: T;
+  onChange: (next: T) => void;
 };
 
-const Pill = ({ checked, onClick, children, ariaLabel }: PillProps) => (
-  <button
-    type="button"
-    className={`pill${checked ? ' pill-checked' : ''}`}
-    aria-pressed={checked}
-    aria-label={ariaLabel}
-    onClick={onClick}
-  >
-    {children}
-  </button>
-);
+const Segmented = <T extends string | boolean>({
+  legend,
+  layoutClass,
+  options,
+  value,
+  onChange,
+}: SegmentedProps<T>) => {
+  const buttonsRef = useRef<Array<HTMLButtonElement | null>>([]);
+
+  const move = useCallback(
+    (delta: number, currentIdx: number) => {
+      const len = options.length;
+      const nextIdx = (currentIdx + delta + len) % len;
+      const next = options[nextIdx].value;
+      onChange(next);
+      // Move focus to follow the selection — standard roving-tabindex behavior.
+      requestAnimationFrame(() => buttonsRef.current[nextIdx]?.focus());
+    },
+    [options, onChange],
+  );
+
+  const onKeyDown = (event: KeyboardEvent<HTMLButtonElement>, idx: number) => {
+    switch (event.key) {
+      case 'ArrowRight':
+      case 'ArrowDown':
+        event.preventDefault();
+        move(1, idx);
+        break;
+      case 'ArrowLeft':
+      case 'ArrowUp':
+        event.preventDefault();
+        move(-1, idx);
+        break;
+      case 'Home':
+        event.preventDefault();
+        onChange(options[0].value);
+        requestAnimationFrame(() => buttonsRef.current[0]?.focus());
+        break;
+      case 'End':
+        event.preventDefault();
+        onChange(options[options.length - 1].value);
+        requestAnimationFrame(() =>
+          buttonsRef.current[options.length - 1]?.focus(),
+        );
+        break;
+    }
+  };
+
+  return (
+    <fieldset className="form-group">
+      <legend>{legend}</legend>
+      <div
+        className={`segmented ${layoutClass}`}
+        role="radiogroup"
+        aria-label={legend}
+      >
+        {options.map((opt, idx) => {
+          const checked = opt.value === value;
+          return (
+            <button
+              key={String(opt.value)}
+              ref={(el) => {
+                buttonsRef.current[idx] = el;
+              }}
+              type="button"
+              role="radio"
+              className={`pill${checked ? ' pill-checked' : ''}`}
+              aria-checked={checked}
+              aria-label={opt.ariaLabel}
+              // Roving tabindex: only the selected option is in the Tab order
+              // so keyboard users move *between groups* with Tab, not between
+              // individual options.
+              tabIndex={checked ? 0 : -1}
+              onClick={() => onChange(opt.value)}
+              onKeyDown={(e) => onKeyDown(e, idx)}
+            >
+              {opt.render}
+            </button>
+          );
+        })}
+      </div>
+    </fieldset>
+  );
+};
 
 export const WelcomeModal = () => {
-  // We only mount/unmount on gamePhase changes — but selectors still need to
-  // be stable, so we read everything we need up-front.
   const startGame = useGameStore((s) => s.startGame);
   const initMode = useGameStore((s) => s.mode);
   const initDifficulty = useGameStore((s) => s.difficulty);
   const initColor = useGameStore((s) => s.humanColor);
   const initTimers = useGameStore((s) => s.timersEnabled);
+  const keyboardHintsVisible = useGameStore((s) => s.keyboardHintsVisible);
 
   const [mode, setMode] = useState<GameMode>(initMode);
   const [difficulty, setDifficulty] = useState<Difficulty>(initDifficulty);
   const [humanColor, setHumanColor] = useState<PieceColor>(initColor);
   const [timersEnabled, setTimersEnabled] = useState<boolean>(initTimers);
 
-  // Pull focus to the modal when it opens so keyboard users land on it. The
-  // first focusable element is the first pill — autoFocus on the Play button
-  // would skip past everything, which feels wrong.
+  // Pull focus to the modal when it opens so keyboard users land on it.
   useEffect(() => {
-    const firstPill = document.querySelector<HTMLButtonElement>('.modal .pill');
+    const firstPill = document.querySelector<HTMLButtonElement>(
+      '.modal .pill[tabindex="0"]',
+    );
     firstPill?.focus();
   }, []);
 
@@ -74,93 +163,93 @@ export const WelcomeModal = () => {
         </p>
 
         <form onSubmit={submit}>
-          <fieldset className="form-group">
-            <legend>Opponent</legend>
-            <div className="segmented segmented-2">
-              <Pill checked={mode === 'pvp'} onClick={() => setMode('pvp')}>
-                Human
-              </Pill>
-              <Pill checked={mode === 'pve'} onClick={() => setMode('pve')}>
-                Computer
-              </Pill>
-            </div>
-          </fieldset>
+          <Segmented<GameMode>
+            legend="Opponent"
+            layoutClass="segmented-2"
+            value={mode}
+            onChange={setMode}
+            options={[
+              { value: 'pvp', render: 'Human' },
+              { value: 'pve', render: 'Computer' },
+            ]}
+          />
 
           {mode === 'pve' && (
-            <fieldset className="form-group">
-              <legend>Difficulty</legend>
-              <div className="segmented segmented-3">
-                <Pill
-                  checked={difficulty === 'easy'}
-                  onClick={() => setDifficulty('easy')}
-                >
-                  Easy
-                </Pill>
-                <Pill
-                  checked={difficulty === 'medium'}
-                  onClick={() => setDifficulty('medium')}
-                >
-                  Medium
-                </Pill>
-                <Pill
-                  checked={difficulty === 'hard'}
-                  onClick={() => setDifficulty('hard')}
-                >
-                  Hard
-                </Pill>
-              </div>
-            </fieldset>
+            <Segmented<Difficulty>
+              legend="Difficulty"
+              layoutClass="segmented-3"
+              value={difficulty}
+              onChange={setDifficulty}
+              options={[
+                { value: 'easy', render: 'Easy' },
+                { value: 'medium', render: 'Medium' },
+                { value: 'hard', render: 'Hard' },
+              ]}
+            />
           )}
 
-          <fieldset className="form-group">
-            <legend>Your piece</legend>
-            <div className="segmented segmented-2">
-              <Pill
-                checked={humanColor === 'red'}
-                onClick={() => setHumanColor('red')}
-                ariaLabel="Play as red, go first"
-              >
-                <span className="piece-dot piece-dot-red" aria-hidden="true" />
-                <span className="pill-stack">
-                  <span>Red</span>
-                  <span className="pill-meta">goes first</span>
-                </span>
-              </Pill>
-              <Pill
-                checked={humanColor === 'black'}
-                onClick={() => setHumanColor('black')}
-                ariaLabel="Play as black, go second"
-              >
-                <span className="piece-dot piece-dot-black" aria-hidden="true" />
-                <span className="pill-stack">
-                  <span>Black</span>
-                  <span className="pill-meta">goes second</span>
-                </span>
-              </Pill>
-            </div>
-          </fieldset>
+          <Segmented<PieceColor>
+            legend="Your piece"
+            layoutClass="segmented-2"
+            value={humanColor}
+            onChange={setHumanColor}
+            options={[
+              {
+                value: 'red',
+                ariaLabel: 'Play as red, go first',
+                render: (
+                  <>
+                    <span
+                      className="piece-dot piece-dot-red"
+                      aria-hidden="true"
+                    />
+                    <span className="pill-stack">
+                      <span>Red</span>
+                      <span className="pill-meta">goes first</span>
+                    </span>
+                  </>
+                ),
+              },
+              {
+                value: 'black',
+                ariaLabel: 'Play as black, go second',
+                render: (
+                  <>
+                    <span
+                      className="piece-dot piece-dot-black"
+                      aria-hidden="true"
+                    />
+                    <span className="pill-stack">
+                      <span>Black</span>
+                      <span className="pill-meta">goes second</span>
+                    </span>
+                  </>
+                ),
+              },
+            ]}
+          />
 
-          <fieldset className="form-group">
-            <legend>Timers</legend>
-            <div className="segmented segmented-2">
-              <Pill
-                checked={timersEnabled}
-                onClick={() => setTimersEnabled(true)}
-              >
-                On
-              </Pill>
-              <Pill
-                checked={!timersEnabled}
-                onClick={() => setTimersEnabled(false)}
-              >
-                Off
-              </Pill>
-            </div>
-          </fieldset>
+          <Segmented<boolean>
+            legend="Timers"
+            layoutClass="segmented-2"
+            value={timersEnabled}
+            onChange={setTimersEnabled}
+            options={[
+              { value: true, render: 'On' },
+              { value: false, render: 'Off' },
+            ]}
+          />
 
           <button type="submit" className="primary-btn">
             Play
           </button>
+
+          {keyboardHintsVisible && (
+            <p className="modal-kb-hint" role="note">
+              Use <kbd>←</kbd> <kbd>→</kbd> to switch options,{' '}
+              <kbd>Tab</kbd> to move between groups, <kbd>Enter</kbd> to play.
+            </p>
+          )}
         </form>
       </div>
     </div>

--- a/src/store.ts
+++ b/src/store.ts
@@ -39,11 +39,18 @@ type GameState = {
   isDraw: boolean;
   playerOneTime: number;
   playerTwoTime: number;
+  /**
+   * Whether the end-game banner is showing. Note: this stays false during the
+   * "win sequence" pause (staggered piece highlight + hold) after a game ends.
+   * App.tsx flips it true via `revealEndOverlay` once the sequence completes.
+   */
   showOverlay: boolean;
   gameBoard: GameBoard;
   winningPieces: WinningPiece[];
   /** Drives the mid-game "return to setup?" confirmation modal. */
   showResetConfirm: boolean;
+  /** Whether to display the keyboard-shortcut hints throughout the app. */
+  keyboardHintsVisible: boolean;
 };
 
 type GameActions = {
@@ -59,6 +66,10 @@ type GameActions = {
   addPiece: (rowIndex: number, columnIndex: number) => void;
   incTimer: () => void;
   setAiThinking: (thinking: boolean) => void;
+  /** Show the end-game banner. Called by App.tsx after the win sequence. */
+  revealEndOverlay: () => void;
+  /** Toggle the visibility of keyboard hints across canvas + modals. */
+  toggleKeyboardHints: () => void;
 };
 
 /**
@@ -91,6 +102,7 @@ const initialState: GameState = {
   gamePhase: 'setup',
   ...defaultConfig,
   aiPlayer: null,
+  keyboardHintsVisible: false,
   ...freshBoardState(),
 };
 
@@ -167,11 +179,16 @@ export const useGameStore = create<GameState & GameActions>((set) => ({
 
       const winningPieces = checkGameBoard(gameBoard);
       if (winningPieces) {
+        // Banner is intentionally NOT shown immediately — App.tsx kicks off
+        // the win-sequence animation (staggered piece highlight + hold) and
+        // calls revealEndOverlay() once that completes. This gives the user
+        // time to see *who* won and *which* pieces won before the menu
+        // prompt covers any UI.
         return {
           gameBoard,
           winningPieces,
           winner: state.currentPlayer,
-          showOverlay: true,
+          showOverlay: false,
           isPlaying: false,
           gamePhase: 'finished' as GamePhase,
           aiThinking: false,
@@ -179,10 +196,11 @@ export const useGameStore = create<GameState & GameActions>((set) => ({
       }
 
       if (isBoardFull(gameBoard)) {
+        // Same staged reveal for draws; just shorter (no pieces to stagger).
         return {
           gameBoard,
           isDraw: true,
-          showOverlay: true,
+          showOverlay: false,
           isPlaying: false,
           gamePhase: 'finished' as GamePhase,
           aiThinking: false,
@@ -205,4 +223,16 @@ export const useGameStore = create<GameState & GameActions>((set) => ({
     }),
 
   setAiThinking: (thinking) => set(() => ({ aiThinking: thinking })),
+
+  revealEndOverlay: () =>
+    set((state) => {
+      // Only act on a finished game; ignore stray calls (e.g. if reset
+      // happened during the win-sequence delay).
+      if (state.gamePhase !== 'finished') return state;
+      if (state.showOverlay) return state;
+      return { showOverlay: true };
+    }),
+
+  toggleKeyboardHints: () =>
+    set((state) => ({ keyboardHintsVisible: !state.keyboardHintsVisible })),
 }));


### PR DESCRIPTION
Three asks bundled together.

## What changed

**1. Removed the between-column dividers** on the yellow board face.

**2. Keyboard hints toggle (desktop-only).** A new viewport-fixed pill in the top-right corner labeled *Show keyboard controls* / *Hide keyboard controls*. Hidden on touch / small viewports via CSS — touch users don't have a keyboard for the hints to apply to. When the toggle is on:

- The canvas paints "1"–"7" above each column during gameplay, mapping the digit keys to drop targets.
- The welcome modal appends a hint footer with inline `<kbd>` keys.
- The reset-confirm modal appends a similar hint footer.

**3. Arrow-key navigation in the menus.** Welcome modal's four segmented controls now implement the WAI-ARIA `radiogroup` pattern: a roving tabindex means **Tab moves between groups** while **arrows cycle within a group** and select-as-you-go. Home/End jump to first/last. Reset-confirm modal swaps Cancel ↔ Return focus with arrow keys.

**4. End-game no longer hides the board.** The centered card is replaced by a slim banner in the same vertical band as the clocks — no canvas dim, no board occlusion. The banner shows the result with an accent stripe in the winner's color (or neutral grey for a draw), and a Menu button on the right.

**5. Win-sequence pause before the banner.** When a winning move lands, the store now defers `showOverlay` while a celebratory pause plays:

      drop completes
        ↓
      piece 0 fades to white  (220 ms)
        ↓  stagger 180 ms
      piece 1 fades to white
        ↓  …
      pieces 2, 3 light up in turn
        ↓  hold 900 ms
      banner fades in

For wins the total pause is about 2 s; for draws (no pieces to stagger), about 1.4 s.

## Implementation highlights

- `store.ts`: `keyboardHintsVisible`, `toggleKeyboardHints`, and a new `revealEndOverlay` action. `addPiece` no longer flips `showOverlay` on game end — it just records the winner / winningPieces and lets the rAF subscriber drive the timing.
- `animations.ts`: new `winSequenceStartedAt`, win-sequence timing constants (`WIN_HIGHLIGHT_STAGGER_MS`, `_FADE_MS`, `_HOLD_MS`), helpers `winSequenceDuration` and `winPieceHighlightProgress`. Old `overlayBackdropAlpha` removed (no more dim).
- `App.tsx`: subscriber detects `gamePhase: playing → finished`, records `anim.winSequenceStartedAt = now + DROP_DURATION_MS` so the highlight doesn't begin mid-air, and schedules `revealEndOverlay()` after the full sequence. Generation counter cancels stale timers if the user resets mid-pause.
- `canvas/scene.ts`: `drawPiecesForBoard` cross-fades each winning piece from its normal-color gradient to a white-gloss gradient at `alpha = highlightProgress`, with the emboss ring fading out and the pulse ring + scale only enabling once the piece is fully highlighted **and** its drop has finished. New `drawColumnKeyHints` paints "1"–"7" above columns. `drawOverlay` rebuilt as `drawEndBanner` — slim, sits in the clocks band, no canvas dim.
- `canvas/layout.ts`: `overlay.card`/`overlay.button` repositioned to the clocks band (same coordinates as the clocks total width); banner's Menu button is inset on the right.
- `components/KeyboardHintsToggle.tsx`: new viewport-fixed toggle.
- `components/WelcomeModal.tsx`: segmented controls refactored into a `<Segmented>` helper that owns roving tabindex + arrow-key navigation. Selection-follows-focus matches the standard radiogroup pattern.
- `components/ResetConfirmModal.tsx`: arrow keys swap focus between Cancel and Return; Esc still dismisses.

## Trade-offs / notes

- Pulse ring + win pulse scale stay gated on `highlightProgress >= 1 && dropProgress >= 1` so they don't pop on while the piece is mid-fade.
- The keyboard toggle is positioned in the *viewport* (not the canvas) per your request; on common desktop widths it stays clearly separated from the canvas-painted MENU button thanks to the canvas-wrap centering and padding. On viewports narrow enough that they'd collide, the media query hides the toggle.
- Win-sequence timing values are tuned for "feels right" (180/220/900 ms). All three constants live in `animations.ts` if you want to tweak the cadence.

https://claude.ai/code/session_01TDMf5QCvZfHQQzTVJ2uRyZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01TDMf5QCvZfHQQzTVJ2uRyZ)_