### PR TITLE
Suppress keyboard hints on mobile; keep attribution visible

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -450,11 +450,6 @@ canvas {
   line-height: 1;
 }
 
-/* On narrow viewports the corner gets crowded; hide on touch / small. */
-@media (max-width: 540px) {
-  .github-attribution { display: none; }
-}
-
 /* ─────────────────────── inline keyboard-hint footers ─────────────────────── */
 
 /*

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -65,6 +65,21 @@ const App = () => {
     });
   }, []);
 
+  // Sync `keyboardHintsSupported` with the viewport. The query mirrors the
+  // CSS rule that hides the toggle button (.kb-toggle): on touch devices and
+  // narrow viewports there's no useful keyboard, so the painted hints
+  // (column digits, Esc chip) and modal hint footers are suppressed too.
+  const setKeyboardHintsSupported = useGameStore(
+    (s) => s.setKeyboardHintsSupported,
+  );
+  useEffect(() => {
+    const mql = window.matchMedia('(max-width: 720px), (hover: none)');
+    const update = () => setKeyboardHintsSupported(!mql.matches);
+    update(); // Seed before first paint.
+    mql.addEventListener('change', update);
+    return () => mql.removeEventListener('change', update);
+  }, [setKeyboardHintsSupported]);
+
   // Global "K" shortcut to toggle keyboard hints. Single key (no Shift+/
   // gymnastics) and mnemonic for "Keyboard". Lives at the document level so
   // it works in every phase (setup, playing, finished, modals open). Bound

--- a/src/canvas/scene.ts
+++ b/src/canvas/scene.ts
@@ -1,5 +1,5 @@
 import { COLUMNS, ROWS, type Cell, type GameBoard, type Player, type WinningPiece } from '../constants';
-import type { useGameStore } from '../store';
+import { selectShowKeyboardHints, type useGameStore } from '../store';
 import {
   cellCenter,
   type Layout,
@@ -978,8 +978,10 @@ export const paint = (
 
   // 8. Column key hints — "1" through "7" above each column. Shown only
   //    while the game is live (a true hint applies only when input matters)
-  //    and the user has the keyboard-hints toggle on.
-  if (state.keyboardHintsVisible && state.gamePhase === 'playing' && !state.showOverlay) {
+  //    and the user has the keyboard-hints toggle on. Suppressed entirely
+  //    on touch / narrow viewports via `selectShowKeyboardHints`.
+  const showHints = selectShowKeyboardHints(state);
+  if (showHints && state.gamePhase === 'playing' && !state.showOverlay) {
     drawColumnKeyHints(ctx, layout);
   }
 
@@ -997,7 +999,7 @@ export const paint = (
   //     is up — that banner has its own Menu button. The Esc-kbd hint chip
   //     below it shows only when the user has keyboard hints enabled.
   if (!state.showOverlay && state.gamePhase === 'playing') {
-    drawMenuButton(ctx, layout, anim, state.keyboardHintsVisible);
+    drawMenuButton(ctx, layout, anim, showHints);
   }
 
   // 12. AI "thinking" pulse, layered above the board but below the banner.

--- a/src/components/GithubAttribution.tsx
+++ b/src/components/GithubAttribution.tsx
@@ -4,8 +4,8 @@
  * with the action ("on GitHub") in one self-contained badge.
  *
  * Opens in a new tab; styled to be unobtrusive (low-contrast background,
- * smaller font) so it doesn't compete with gameplay UI. Hidden on very
- * narrow viewports via CSS to keep the bottom corner clean on phones.
+ * smaller font) so it doesn't compete with gameplay UI. Stays visible on
+ * mobile too — credit shouldn't be platform-conditional.
  *
  * Sits below the modal backdrop in z-order — it's reference material,
  * not gameplay UI that needs to remain clickable through a modal.

--- a/src/components/ResetConfirmModal.tsx
+++ b/src/components/ResetConfirmModal.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useRef } from 'react';
 
-import { useGameStore } from '../store';
+import { selectShowKeyboardHints, useGameStore } from '../store';
 
 /**
  * Confirmation dialog shown when the player clicks the in-game MENU button.
@@ -10,7 +10,7 @@ import { useGameStore } from '../store';
 export const ResetConfirmModal = () => {
   const cancelResetRequest = useGameStore((s) => s.cancelResetRequest);
   const openSetup = useGameStore((s) => s.openSetup);
-  const keyboardHintsVisible = useGameStore((s) => s.keyboardHintsVisible);
+  const keyboardHintsVisible = useGameStore(selectShowKeyboardHints);
   const cancelButtonRef = useRef<HTMLButtonElement>(null);
   const confirmButtonRef = useRef<HTMLButtonElement>(null);
 

--- a/src/components/WelcomeModal.tsx
+++ b/src/components/WelcomeModal.tsx
@@ -7,7 +7,7 @@ import {
   type ReactNode,
 } from 'react';
 
-import { useGameStore } from '../store';
+import { selectShowKeyboardHints, useGameStore } from '../store';
 import type { Difficulty, GameMode, PieceColor } from '../constants';
 
 /**
@@ -126,7 +126,7 @@ export const WelcomeModal = () => {
   const initDifficulty = useGameStore((s) => s.difficulty);
   const initColor = useGameStore((s) => s.humanColor);
   const initTimers = useGameStore((s) => s.timersEnabled);
-  const keyboardHintsVisible = useGameStore((s) => s.keyboardHintsVisible);
+  const keyboardHintsVisible = useGameStore(selectShowKeyboardHints);
 
   const [mode, setMode] = useState<GameMode>(initMode);
   const [difficulty, setDifficulty] = useState<Difficulty>(initDifficulty);

--- a/src/store.ts
+++ b/src/store.ts
@@ -51,6 +51,13 @@ type GameState = {
   showResetConfirm: boolean;
   /** Whether to display the keyboard-shortcut hints throughout the app. */
   keyboardHintsVisible: boolean;
+  /**
+   * Whether the current device/viewport can usefully act on keyboard hints.
+   * False on touch devices and narrow viewports — there's no physical keyboard
+   * to follow the hints, and the toggle button itself is CSS-hidden there.
+   * App.tsx keeps this in sync with a matchMedia listener.
+   */
+  keyboardHintsSupported: boolean;
 };
 
 type GameActions = {
@@ -70,6 +77,8 @@ type GameActions = {
   revealEndOverlay: () => void;
   /** Toggle the visibility of keyboard hints across canvas + modals. */
   toggleKeyboardHints: () => void;
+  /** Driven from App.tsx's matchMedia listener; see GameState.keyboardHintsSupported. */
+  setKeyboardHintsSupported: (supported: boolean) => void;
 };
 
 /**
@@ -106,6 +115,9 @@ const initialState: GameState = {
   // turning them off is a deliberate choice the user can make via the
   // viewport toggle (or by pressing "?"). Defaulting off hid useful info.
   keyboardHintsVisible: true,
+  // Optimistic default; App.tsx corrects this on mount via matchMedia and
+  // keeps it in sync as the viewport changes (resize, orientation).
+  keyboardHintsSupported: true,
   ...freshBoardState(),
 };
 
@@ -238,4 +250,17 @@ export const useGameStore = create<GameState & GameActions>((set) => ({
 
   toggleKeyboardHints: () =>
     set((state) => ({ keyboardHintsVisible: !state.keyboardHintsVisible })),
+
+  setKeyboardHintsSupported: (supported) =>
+    set(() => ({ keyboardHintsSupported: supported })),
 }));
+
+/**
+ * Effective keyboard-hint visibility: the user's preference AND a viewport
+ * that can act on hints. Use this in every consumer EXCEPT the toggle button
+ * itself (which mirrors the user's stored preference, since its own
+ * visibility is already CSS-gated to keyboard-friendly viewports).
+ */
+export const selectShowKeyboardHints = (
+  state: GameState & GameActions,
+): boolean => state.keyboardHintsVisible && state.keyboardHintsSupported;


### PR DESCRIPTION
The keyboard-hints toggle button is already CSS-hidden on touch / narrow
viewports, but the hints it controls (column digits, Esc chip, modal
<kbd> footers) still rendered if 'keyboardHintsVisible' was on — leaving
hints with no way to turn them off.

Add 'keyboardHintsSupported' to the store, kept in sync with the same
matchMedia query the CSS uses, and a 'selectShowKeyboardHints' selector
that ANDs it with the user's preference. All hint consumers (canvas
scene + both modals) use the selector; the toggle button itself still
reads the raw preference (its own visibility is already CSS-gated).

Also drop the (max-width: 540px) display:none on the GitHub attribution
pill — credit shouldn't be platform-conditional, and the request was
explicitly to keep it visible on mobile with no style adjustments.

https://claude.ai/code/session_014UYiKTg6kLnBUm3LRCLWmE