### PR TITLE
Stronger AI: fix play() bug, add TT + iterative deepening, parity eval

### DIFF
--- a/src/ai/bitboard.ts
+++ b/src/ai/bitboard.ts
@@ -57,13 +57,25 @@ export const canPlay = (pos: Position, col: number): boolean =>
  * Play `col`. Returns a new Position with player perspective swapped — i.e.
  * `position` afterwards represents the pieces of the player whose turn is
  * now next. Caller must check `canPlay(pos, col)` first.
+ *
+ * Order matters: we XOR `position` with the OLD mask first (which converts
+ * "current mover's pieces" into "opponent's pieces" = new mover's pieces),
+ * then update the mask to include the just-played piece. Doing it the other
+ * way around — XORing with the new mask — would fold the just-played piece
+ * (which belongs to the old mover, not the new mover) into `position`, and
+ * silently corrupt every subsequent eval and search.
  */
 export const play = (pos: Position, col: number): Position => {
-  // `mask + bottomBit(col)` carries the bit up to the lowest empty slot in
-  // column c; ORing into mask seats the new piece there.
+  // Step 1: swap perspective. Before any new piece is placed, the new mover's
+  // pieces are exactly the old opponent's pieces = pos.mask XOR pos.position.
+  const swappedPosition = pos.position ^ pos.mask;
+  // Step 2: drop the piece. `mask + bottomBit(col)` carries up to the lowest
+  // empty slot in the column; ORing into mask seats the new piece there. The
+  // piece belongs to the old mover (now the new opponent), so it's correctly
+  // absent from `swappedPosition`.
   const newMask = pos.mask | (pos.mask + bottomBit(col));
   return {
-    position: pos.position ^ newMask, // swap perspective: old "us" now becomes "opponent" in the new view
+    position: swappedPosition,
     mask: newMask,
     moves: pos.moves + 1,
   };

--- a/src/ai/engine.ts
+++ b/src/ai/engine.ts
@@ -1,4 +1,4 @@
-import { type Difficulty, type GameBoard, type Player } from '../constants';
+import { COLUMNS, ROWS, type Difficulty, type GameBoard, type Player } from '../constants';
 import {
   canPlay,
   fromGameBoard,
@@ -6,7 +6,7 @@ import {
   opponentView,
   type Position,
 } from './bitboard';
-import { MATE_SCORE, scoreAllMoves } from './search';
+import { MATE_SCORE, scoreAllMoves, type SearchOptions } from './search';
 
 /**
  * Choose a column for the AI to play. Three difficulty profiles:
@@ -15,23 +15,45 @@ import { MATE_SCORE, scoreAllMoves } from './search';
  *            immediate loss, otherwise weighted-random with a center bias.
  *            Plays like a casual human who isn't reading ahead. No search.
  *
- *   medium — depth-4 negamax with α-β. Occasionally picks the 2nd-best move
- *            when the gap is small, so it doesn't feel mechanical. Strong
- *            tactical play but blunderable.
+ *   medium — iterative-deepening negamax with α-β + TT, capped at depth 7 with
+ *            a ~800ms wall-clock budget. Occasionally picks the 2nd-best move
+ *            when the score gap is tiny, so it doesn't feel mechanical. Strong
+ *            tactical play but blunderable on long-range traps.
  *
- *   hard   — depth-7 negamax with α-β. Plays accurately within its horizon —
- *            spots traps several moves out and rarely walks into one.
+ *   hard   — same engine, uncapped depth (up to MAX_MOVES) with a ~2500ms
+ *            budget. Within the budget it iteratively deepens; late-game
+ *            positions are fully solved (search depth = remaining cells). The
+ *            heuristic understands Connect 4's parity / zugzwang principle, so
+ *            even mid-game decisions are made with the right long-range
+ *            objective in mind.
  */
 
 const MOVE_ORDER: readonly number[] = [3, 4, 2, 5, 1, 6, 0];
 
-// Per-difficulty search depths. Hard at 7 keeps single-move thinking well
-// under a quarter-second even on slow phones, with BigInt eval.
-const DEPTH: Record<Difficulty, number> = {
-  easy: 0, // unused — easyMove doesn't search
-  medium: 4,
-  hard: 7,
+// Total cells on the board — used as an unbounded depth cap for hard mode.
+// Once iterative deepening reaches movesRemaining = MAX_MOVES - pos.moves, the
+// search is exhaustive and the result is the true game-theoretic value.
+const MAX_MOVES = COLUMNS * ROWS;
+
+const SEARCH_OPTIONS: Record<Exclude<Difficulty, 'easy'>, SearchOptions> = {
+  // Medium intentionally caps depth: we want a recognizable tactical level,
+  // not a "strong solver with a slow timer". The budget is a safety net for
+  // dense midgame positions.
+  medium: { maxDepth: 7, budgetMs: 800 },
+  // Hard is "solve when feasible". MAX_MOVES disables the depth cap; the
+  // 2500ms budget keeps single-turn freezes bounded on slower devices. Late-
+  // game positions (movesRemaining small) finish well under budget and return
+  // perfect play; early-game positions return the deepest completed depth.
+  hard: { maxDepth: MAX_MOVES, budgetMs: 2500 },
 };
+
+// Medium's "soft" preference window: when the top two moves are within this
+// many points AND the score isn't anywhere near a mate, medium has a chance
+// to take the 2nd-best move. Tightened from the previous (depth-4-era) value
+// of 25 because deeper search produces a finer-grained score distribution —
+// 25 used to mean "essentially identical moves", now it's "noticeably worse".
+const MEDIUM_SOFT_WINDOW = 8;
+const MEDIUM_SANDBAG_PROB = 0.18;
 
 const playableColumns = (pos: Position): number[] => {
   const cols: number[] = [];
@@ -79,27 +101,31 @@ export const chooseMove = (
 
   if (difficulty === 'easy') return easyMove(pos);
 
-  const scored = scoreAllMoves(pos, DEPTH[difficulty]);
-  if (scored.length === 0) return 3; // unreachable — engine only called mid-game
+  const scored = scoreAllMoves(pos, SEARCH_OPTIONS[difficulty]);
+  // scoreAllMoves always returns at least one move when called mid-game.
+  // The "no playable column" case (board full) is handled by the caller in
+  // App.tsx — we'd never get here. Belt-and-suspenders: column 3.
+  if (scored.length === 0) return 3;
 
   const best = scored[0];
 
   if (difficulty === 'medium') {
-    // 30% of the time, if the top two moves are within a "soft" gap, pick the
-    // second. This produces a player that reads ahead but doesn't always
-    // commit to the optimal line — feels like a competent casual opponent.
-    // Forced wins are never sandbagged: if the best move is a mate, take it.
+    // Slight sandbagging: when the top two moves are tactically equivalent
+    // (gap below MEDIUM_SOFT_WINDOW) and neither is a forced mate, pick the
+    // 2nd-best with low probability. This adds a touch of unpredictability
+    // without throwing actually-better moves overboard. Forced wins/losses
+    // are always played straight.
     if (
       scored.length >= 2 &&
-      Math.abs(best.score) < MATE_SCORE - 100 &&
-      Math.abs(best.score - scored[1].score) < 25 &&
-      Math.random() < 0.3
+      Math.abs(best.score) < MATE_SCORE - ROWS * COLUMNS &&
+      Math.abs(best.score - scored[1].score) < MEDIUM_SOFT_WINDOW &&
+      Math.random() < MEDIUM_SANDBAG_PROB
     ) {
       return scored[1].col;
     }
     return best.col;
   }
 
-  // hard: best move, no sandbagging
+  // hard: best move, no sandbagging.
   return best.col;
 };

--- a/src/ai/eval.ts
+++ b/src/ai/eval.ts
@@ -2,13 +2,32 @@ import { COLUMNS, ROWS, WIN_LENGTH } from '../constants';
 import { bitAt, type Position } from './bitboard';
 
 /**
- * Heuristic evaluation for non-terminal nodes. Returns a score in the current
- * mover's perspective: positive = better for the player whose turn it is.
+ * Heuristic evaluation for non-terminal leaf nodes. Returns a score from the
+ * current mover's perspective: positive = better for whoever is to move.
  *
- * Approach: enumerate all 69 possible 4-in-a-row line positions on the board,
- * and for each, count how many cells each side already owns. A line with one
- * side's pieces and no opposing pieces is a "potential threat" weighted by how
- * close it is to completing. Plus a small center-column bonus.
+ * Three layers, summed:
+ *
+ *   1. Line density. Each of the 69 possible 4-in-a-row line positions is
+ *      classified by which side(s) already own cells in it. A line with one
+ *      side's pieces and no opposing pieces is a "potential threat" weighted
+ *      by how close it is to completing.
+ *
+ *   2. Center column bonus. Cells in the center column appear in more lines
+ *      than any other column, so they're worth a small explicit nudge so the
+ *      engine values them correctly at shallow depths.
+ *
+ *   3. Parity-aware threat scoring. For each line where one side has exactly
+ *      three of the four cells and the fourth is empty, the empty completion
+ *      square is a "threat". Threats are weighted heavily, with an extra
+ *      bonus when the threat sits on a row whose bottom-up parity favors
+ *      the threat owner — the canonical Connect 4 zugzwang principle:
+ *      first player (red) wants threats on odd rows from the bottom (1, 3, 5),
+ *      second player (black) wants threats on even rows (2, 4, 6). Stacked
+ *      threats in the same column are scored cumulatively; double-threats are
+ *      effectively unblockable and the engine should learn to chase them.
+ *
+ * All scores stay well below MATE_SCORE - MAX_MOVES so a proven mate always
+ * dominates the heuristic.
  */
 
 const LINE_MASKS: bigint[] = (() => {
@@ -44,9 +63,57 @@ const CENTER_MASK: bigint = (() => {
   return m;
 })();
 
+/**
+ * Per-row parity bonus for the *first* player's threats. Indexed by top-down
+ * row (0 = top, 5 = bottom). A first-mover threat on a bottom-up odd row
+ * (top-down 5, 3, 1) is favored; even rows are unfavored.
+ *
+ * The second player's bonus uses the inverse table. The conversion
+ * "first-mover-threat-row → second-mover-threat-row" is the same table read
+ * with the parity flipped, which is what BOTTOM_UP_PARITY computes.
+ */
+// Bottom-up row index (1..6) for each top-down row (0..5). Top-down 0 = top,
+// which is bottom-up ROWS = 6; top-down 5 = bottom, which is bottom-up 1.
+const BOTTOM_UP_ROW: readonly number[] = (() => {
+  const arr: number[] = [];
+  for (let row = 0; row < ROWS; row++) arr.push(ROWS - row);
+  return arr;
+})();
+
+// Bitmasks of all cells whose bottom-up row is odd (favored for first player)
+// and even (favored for second player). Used to score threat squares in a
+// single bitwise op rather than iterating cells.
+const ODD_ROW_MASK: bigint = (() => {
+  let m = 0n;
+  for (let col = 0; col < COLUMNS; col++) {
+    for (let row = 0; row < ROWS; row++) {
+      if (BOTTOM_UP_ROW[row] % 2 === 1) m |= bitAt(col, row);
+    }
+  }
+  return m;
+})();
+const EVEN_ROW_MASK: bigint = (() => {
+  let m = 0n;
+  for (let col = 0; col < COLUMNS; col++) {
+    for (let row = 0; row < ROWS; row++) {
+      if (BOTTOM_UP_ROW[row] % 2 === 0) m |= bitAt(col, row);
+    }
+  }
+  return m;
+})();
+
 // 0..4 pieces in line → score weight. The jump from 2→3 is large on purpose;
 // a 3-in-a-row with one open end is one move from victory.
 const PIECE_COUNT_WEIGHT = [0, 1, 10, 50, 0] as const;
+
+// Bonus added to a threat (3-of-4 line, 1 empty) sitting on the threat owner's
+// favored row parity. Layered ON TOP of the existing 50-point line-density
+// weight, so a favored-parity threat is worth 50 + THREAT_PARITY_BONUS.
+const THREAT_PARITY_BONUS = 30;
+// Smaller bonus when the threat is on the *wrong* parity — it's still a
+// threat, just less reliable. Keeps the engine from undervaluing immediate
+// tactical pressure in service of long-range parity dreams.
+const THREAT_OFF_PARITY_BONUS = 6;
 
 /** Count bits in a BigInt that's known to have at most a few set. */
 const popcountSmall = (b: bigint): number => {
@@ -62,16 +129,43 @@ const popcountSmall = (b: bigint): number => {
 export const evaluatePosition = (pos: Position): number => {
   const me = pos.position;
   const them = pos.mask ^ pos.position;
+  const empty = ~pos.mask; // includes off-board bits, but we always AND with line masks before consuming
+
+  // Whose move parity matches "first player overall"? At move 0 the first
+  // player is to move (pos.moves === 0, even). So even pos.moves → I am the
+  // first player; odd → I am the second.
+  const meIsFirst = (pos.moves & 1) === 0;
+  const myFavoredRows = meIsFirst ? ODD_ROW_MASK : EVEN_ROW_MASK;
+  const themFavoredRows = meIsFirst ? EVEN_ROW_MASK : ODD_ROW_MASK;
 
   let score = 0;
   for (const line of LINE_MASKS) {
     const mineInLine = line & me;
     const theirsInLine = line & them;
-    if (mineInLine !== 0n && theirsInLine !== 0n) continue; // blocked, no value
+    if (mineInLine !== 0n && theirsInLine !== 0n) continue; // blocked — no value to either side
+
     if (mineInLine !== 0n) {
-      score += PIECE_COUNT_WEIGHT[popcountSmall(mineInLine)];
+      const cnt = popcountSmall(mineInLine);
+      score += PIECE_COUNT_WEIGHT[cnt];
+      // Parity overlay for a real threat (3 of 4, 1 empty). The empty cell is
+      // exactly `line & empty`; classify by which parity-row mask it falls in.
+      if (cnt === 3) {
+        const threatSquare = line & empty;
+        score +=
+          (threatSquare & myFavoredRows) !== 0n
+            ? THREAT_PARITY_BONUS
+            : THREAT_OFF_PARITY_BONUS;
+      }
     } else if (theirsInLine !== 0n) {
-      score -= PIECE_COUNT_WEIGHT[popcountSmall(theirsInLine)];
+      const cnt = popcountSmall(theirsInLine);
+      score -= PIECE_COUNT_WEIGHT[cnt];
+      if (cnt === 3) {
+        const threatSquare = line & empty;
+        score -=
+          (threatSquare & themFavoredRows) !== 0n
+            ? THREAT_PARITY_BONUS
+            : THREAT_OFF_PARITY_BONUS;
+      }
     }
   }
 

--- a/src/ai/search.ts
+++ b/src/ai/search.ts
@@ -3,38 +3,154 @@ import { canPlay, isWinningMove, play, type Position } from './bitboard';
 import { evaluatePosition } from './eval';
 
 /**
- * Negamax search with α-β pruning. Returns a score from the current mover's
- * perspective. A larger score is better for the player to move.
+ * Negamax search with α-β pruning, transposition table, killer moves, and
+ * iterative deepening. Returns scores from the current mover's perspective —
+ * larger is better for the player to move.
  *
- * We score wins as `MAX_SCORE - ply` so that a win in fewer moves is preferred
- * to a win in more moves (and conversely we prefer losses farther away). The
- * scoreAllMoves wrapper drives a top-level move loop and collects per-move
- * scores so the engine can sample from near-best moves at medium difficulty.
+ * Score scheme
+ * ------------
+ *   Terminal win    : MATE_SCORE - pos.moves - 1  (winning sooner > later)
+ *   Heuristic leaf  : bounded well below MATE_SCORE so a real mate always beats any heuristic value
+ *   Drawn position  : 0
+ *
+ * Performance levers
+ * ------------------
+ *   1. Transposition table — keyed on a canonical 98-bit composite of position
+ *      + mask, with depth-bounded entries holding {score, flag, bestMove}.
+ *      Cuts node count dramatically on positions reachable by multiple move
+ *      orders, which is most of them.
+ *   2. Iterative deepening — search depth 1, 2, 3, … up to the requested limit.
+ *      Each pass leaves TT entries with a `bestMove`, which the next pass tries
+ *      first; that alone usually halves the node count of the final pass.
+ *   3. Killer-move heuristic — at each ply we remember the last two moves that
+ *      caused a β-cutoff and try them ahead of the static center-out order.
+ *   4. Time budget — `scoreAllMoves` accepts a deadline and aborts cleanly when
+ *      it lapses. The iterative-deepening wrapper discards the unfinished pass
+ *      and returns the last completed one, so we never return garbage.
  */
 
 const MAX_MOVES = COLUMNS * ROWS; // 42
 
-// A score that comfortably exceeds the maximum the heuristic can produce, so
-// terminal wins always beat any heuristic value.
+/**
+ * Comfortably above any heuristic value the leaf evaluator can produce, so
+ * proven mates always sort above heuristic scores. The MATE_SCORE - pos.moves
+ * offset makes "win in N" preferred over "win in N+1".
+ */
 export const MATE_SCORE = 100000;
 
-// Center-out move ordering: in Connect 4 the center column is by far the most
-// valuable, then adjacent columns. Trying it first dramatically improves the
-// number of α-β cutoffs.
-const MOVE_ORDER: readonly number[] = [3, 4, 2, 5, 1, 6, 0];
+/** Above which a score is treated as a proven win/loss (mate-in-K). */
+const MATE_THRESHOLD = MATE_SCORE - MAX_MOVES;
+
+// Center-out static order: in Connect 4 the middle column dominates, then
+// adjacency falls off symmetrically. This is the baseline ordering — TT-best
+// move and killers override per-position.
+const STATIC_ORDER: readonly number[] = [3, 4, 2, 5, 1, 6, 0];
+
+const FLAG_EXACT = 0;
+const FLAG_LOWER = 1; // stored score is a lower bound on true score
+const FLAG_UPPER = 2; // stored score is an upper bound on true score
+type TTFlag = typeof FLAG_EXACT | typeof FLAG_LOWER | typeof FLAG_UPPER;
+
+type TTEntry = {
+  score: number;
+  /** Search depth that produced this entry — re-usable only if ≥ current need. */
+  depth: number;
+  flag: TTFlag;
+  /** -1 if no move was tried (e.g. terminal). Otherwise the best (or first refuting) column. */
+  bestMove: number;
+};
+
+/**
+ * Canonical position key. Bitboard cells fit in 49 bits per side, so packing
+ * (mask, position) into 98 bits gives a collision-free key — every distinct
+ * position maps to a distinct BigInt. Map keys on BigInt are hashed natively
+ * (Node/V8) without string conversion.
+ */
+const positionKey = (pos: Position): bigint =>
+  pos.position | (pos.mask << 49n);
+
+type SearchCtx = {
+  tt: Map<bigint, TTEntry>;
+  /** killers[ply] = up to two columns that recently caused a β-cutoff at that ply. */
+  killers: number[][];
+  /** Absolute deadline in performance.now() ms; 0 disables time checks. */
+  deadline: number;
+  aborted: boolean;
+  nodes: number;
+};
+
+/**
+ * Node-count interval between deadline checks. performance.now() is fast but
+ * not free; checking every 4096 nodes keeps overhead near 0% while bounding
+ * overshoot to a handful of ms at typical search rates.
+ */
+const NODE_CHECK_MASK = 4095; // power-of-two − 1 for bitmask test
+
+const checkDeadline = (ctx: SearchCtx): void => {
+  if (ctx.deadline === 0) return;
+  if (performance.now() > ctx.deadline) ctx.aborted = true;
+};
+
+/**
+ * Ordered move list for a node. The TT's bestMove (if present) goes first,
+ * then the two killer columns for this ply, then the static center-out order
+ * for everything else. Duplicates and unplayable columns are filtered.
+ */
+const orderMoves = (
+  pos: Position,
+  ttMove: number,
+  killers: readonly number[] | undefined,
+): number[] => {
+  const out: number[] = [];
+  const seen = new Uint8Array(COLUMNS);
+  const push = (c: number): void => {
+    if (c < 0 || c >= COLUMNS) return;
+    if (seen[c]) return;
+    if (!canPlay(pos, c)) return;
+    seen[c] = 1;
+    out.push(c);
+  };
+  push(ttMove);
+  if (killers) {
+    push(killers[0] ?? -1);
+    push(killers[1] ?? -1);
+  }
+  for (const c of STATIC_ORDER) push(c);
+  return out;
+};
+
+const recordKiller = (killers: number[][], ply: number, col: number): void => {
+  let slot = killers[ply];
+  if (slot === undefined) {
+    slot = [];
+    killers[ply] = slot;
+  }
+  if (slot[0] === col) return; // already the primary killer
+  slot[1] = slot[0];
+  slot[0] = col;
+};
 
 const negamax = (
   pos: Position,
   depth: number,
   alphaIn: number,
-  beta: number,
+  betaIn: number,
+  ply: number,
+  ctx: SearchCtx,
 ): number => {
-  // Draw: every cell filled with no win.
+  // Periodic deadline check — the returned score is meaningless when aborted,
+  // but we still need to unwind cleanly. The IDS wrapper discards any pass
+  // that touched ctx.aborted, so propagated garbage never reaches the caller.
+  if ((++ctx.nodes & NODE_CHECK_MASK) === 0) checkDeadline(ctx);
+  if (ctx.aborted) return 0;
+
+  // Draw by exhaustion.
   if (pos.moves === MAX_MOVES) return 0;
 
-  // If any legal move wins immediately, take it — short-circuits the recursion
-  // and yields a "win-soon" score.
-  for (const col of MOVE_ORDER) {
+  // Immediate-win shortcut: if any legal move wins right now, take the
+  // shortest mate score and return. This skips both the TT lookup and the
+  // recursion below for terminal-in-1 nodes — a frequent case.
+  for (const col of STATIC_ORDER) {
     if (canPlay(pos, col) && isWinningMove(pos, col)) {
       return MATE_SCORE - pos.moves - 1;
     }
@@ -43,40 +159,163 @@ const negamax = (
   if (depth === 0) return evaluatePosition(pos);
 
   let alpha = alphaIn;
-  let best = -MATE_SCORE * 2;
-  for (const col of MOVE_ORDER) {
-    if (!canPlay(pos, col)) continue;
-    const child = play(pos, col);
-    const score = -negamax(child, depth - 1, -beta, -alpha);
-    if (score > best) best = score;
-    if (best > alpha) alpha = best;
-    if (alpha >= beta) break; // α-β cutoff
+  let beta = betaIn;
+  const key = positionKey(pos);
+  const tte = ctx.tt.get(key);
+  let ttMove = -1;
+  if (tte !== undefined) {
+    ttMove = tte.bestMove;
+    if (tte.depth >= depth) {
+      const s = tte.score;
+      if (tte.flag === FLAG_EXACT) return s;
+      if (tte.flag === FLAG_LOWER) {
+        if (s > alpha) alpha = s;
+      } else if (tte.flag === FLAG_UPPER) {
+        if (s < beta) beta = s;
+      }
+      if (alpha >= beta) return s;
+    }
   }
+
+  let best = -MATE_SCORE * 2;
+  let bestMove = -1;
+  const moves = orderMoves(pos, ttMove, ctx.killers[ply]);
+
+  for (const col of moves) {
+    const child = play(pos, col);
+    const score = -negamax(child, depth - 1, -beta, -alpha, ply + 1, ctx);
+    if (ctx.aborted) return 0;
+    if (score > best) {
+      best = score;
+      bestMove = col;
+    }
+    if (best > alpha) alpha = best;
+    if (alpha >= beta) {
+      recordKiller(ctx.killers, ply, col);
+      break;
+    }
+  }
+
+  // TT store. Flag follows the standard fail-soft convention:
+  //   best ≤ alphaIn  → upper bound (no move raised α; true value is ≤ best)
+  //   best ≥ beta     → lower bound (β-cutoff; true value is ≥ best)
+  //   else            → exact value within the (alphaIn, beta) window
+  const flag: TTFlag =
+    best <= alphaIn ? FLAG_UPPER : best >= betaIn ? FLAG_LOWER : FLAG_EXACT;
+  ctx.tt.set(key, { score: best, depth, flag, bestMove });
   return best;
 };
 
 export type ScoredMove = { col: number; score: number };
 
+export type SearchOptions = {
+  /** Hard upper bound on iterative-deepening depth. Cap at MAX_MOVES to allow full solve. */
+  maxDepth: number;
+  /**
+   * Soft wall-clock budget. The current iteration is allowed to finish if it's
+   * already started; deeper iterations only begin if the deadline hasn't passed.
+   * 0 disables time checks (the search runs to maxDepth unconditionally).
+   */
+  budgetMs: number;
+};
+
 /**
- * Score every legal move from the given position. Returned sorted best-first.
- * Used by the engine to pick the top move (or near-top, on medium difficulty).
+ * Top-level entry: iterative deepening + per-iteration root move loop. Returns
+ * the moves of the deepest *completed* iteration, sorted best-first.
+ *
+ * Iteration cadence: a fresh TT is allocated per call. The TT persists across
+ * the iterations *within* this call, so depth-(d-1) results massively help
+ * order depth-d searches. We deliberately don't keep the TT across calls — the
+ * board has changed, many entries are stale, and 42-cell games don't repeat
+ * positions enough to justify the bookkeeping.
  */
-export const scoreAllMoves = (pos: Position, depth: number): ScoredMove[] => {
-  const scores: ScoredMove[] = [];
+export const scoreAllMoves = (
+  pos: Position,
+  options: SearchOptions,
+): ScoredMove[] => {
+  const ctx: SearchCtx = {
+    tt: new Map(),
+    killers: [],
+    deadline: options.budgetMs > 0 ? performance.now() + options.budgetMs : 0,
+    aborted: false,
+    nodes: 0,
+  };
 
-  for (const col of MOVE_ORDER) {
-    if (!canPlay(pos, col)) continue;
+  // Cap effective depth at "moves remaining" — beyond that, deeper iterations
+  // are pure waste because the tree's already exhausted. When maxDepth meets
+  // this cap, the search becomes a strong solver: a completed iteration at
+  // depth = movesRemaining is exhaustive, and its score is the true game-
+  // theoretic value of the position.
+  const movesRemaining = MAX_MOVES - pos.moves;
+  const effectiveMax = Math.min(options.maxDepth, movesRemaining);
 
-    // Immediate-win shortcut at the root, same idea as inside negamax.
-    if (isWinningMove(pos, col)) {
-      scores.push({ col, score: MATE_SCORE - pos.moves - 1 });
-      continue;
+  let best: ScoredMove[] = [];
+
+  for (let depth = 1; depth <= effectiveMax; depth++) {
+    // Run a depth-`depth` search at the root, collecting per-move scores so
+    // the engine can pick the best (or near-best). We don't reuse `negamax`
+    // here because we want all root scores, not just an α-β-pruned best.
+    const scored: ScoredMove[] = [];
+    let alpha = -MATE_SCORE * 2;
+    const beta = MATE_SCORE * 2;
+    let rootBestMove = -1;
+
+    // Root move ordering mirrors orderMoves: TT-best first, then static order.
+    const rootKey = positionKey(pos);
+    const rootTte = ctx.tt.get(rootKey);
+    const rootTtMove = rootTte?.bestMove ?? -1;
+    const rootMoves = orderMoves(pos, rootTtMove, undefined);
+
+    for (const col of rootMoves) {
+      let score: number;
+      if (isWinningMove(pos, col)) {
+        score = MATE_SCORE - pos.moves - 1;
+      } else {
+        const child = play(pos, col);
+        score = -negamax(child, depth - 1, -beta, -alpha, 1, ctx);
+      }
+      if (ctx.aborted) break;
+      scored.push({ col, score });
+      if (score > alpha) {
+        alpha = score;
+        rootBestMove = col;
+      }
     }
 
-    const child = play(pos, col);
-    const score = -negamax(child, depth - 1, -MATE_SCORE * 2, MATE_SCORE * 2);
-    scores.push({ col, score });
+    if (ctx.aborted) break;
+
+    // Stash the root's best move in the TT so the next iteration probes it first.
+    if (rootBestMove !== -1) {
+      ctx.tt.set(rootKey, {
+        score: alpha,
+        depth,
+        flag: FLAG_EXACT,
+        bestMove: rootBestMove,
+      });
+    }
+
+    scored.sort((a, b) => b.score - a.score);
+    best = scored;
+
+    // Early exit on proven mate — deeper searches can only confirm it, never
+    // contradict it, and we'd rather get the move on screen quickly.
+    if (best.length > 0 && Math.abs(best[0].score) >= MATE_THRESHOLD) break;
   }
 
-  return scores.sort((a, b) => b.score - a.score);
+  // Guarantee at least one move is returned. The depth-1 pass is so cheap
+  // (≤ 7 leaf evals) that even a microsecond-tight budget completes it. But
+  // belt-and-suspenders: if `best` somehow stayed empty, fall back to a
+  // raw root scan with no recursion.
+  if (best.length === 0) {
+    for (const col of STATIC_ORDER) {
+      if (!canPlay(pos, col)) continue;
+      const score = isWinningMove(pos, col)
+        ? MATE_SCORE - pos.moves - 1
+        : evaluatePosition(play(pos, col)) * -1;
+      best.push({ col, score });
+    }
+    best.sort((a, b) => b.score - a.score);
+  }
+
+  return best;
 };


### PR DESCRIPTION
The CPU opponent was consistently beatable on medium and hard. Three compounding fixes:

### 1. Fix a pre-existing bug in `bitboard.play()`

`position` was XORed with the **new** mask instead of the **old** mask:

```ts
// before
const newMask = pos.mask | (pos.mask + bottomBit(col));
return { position: pos.position ^ newMask, mask: newMask, ... };
```

In Pons' canonical encoding `position` should hold the pieces of the player to move. The buggy formula folded the just-played piece (belonging to the player who *just* moved, i.e. the new opponent) into the new mover's `position` field. Every internal-node eval then read the wrong pieces as "mine" vs "theirs", flipping the sign of scores returned up through the search.

Net effect on the old engine: at the root, the search picked the column with the **worst** heuristic for itself — corner columns instead of the center. Easy mode wasn't affected because it doesn't search.

Fix uses Pons' formula directly: XOR with the *old* mask first, then update the mask.

### 2. Rewrite `search.ts` with TT + killers + iterative deepening + budget

- **Transposition table** keyed on `position | (mask << 49n)` — collision-free 98-bit composite. Entries store `{score, depth, flag, bestMove}` with EXACT/LOWER/UPPER bounds.
- **Iterative deepening** seeds each pass's move ordering from the previous pass's TT-`bestMove`. Typically halves the node count at the final depth.
- **Killer-move heuristic** per ply: the last two columns that produced a β-cutoff are tried before the static center-out order.
- **Wall-clock budget** with periodic deadline checks (every 4096 nodes). The IDS wrapper discards any pass that aborted mid-way and returns the last completed iteration's result, so we never return garbage.

### 3. Parity-aware threat scoring in `eval.ts`

Existing line-density and center-column terms stay. Added: each 3-of-4 line with one empty cell gets an extra bonus based on the bottom-up row parity of that empty completion square. First-mover threats on odd rows (1, 3, 5 from the bottom) get +30; second-mover threats on even rows get +30; off-parity threats get +6. This is the canonical Connect 4 zugzwang principle — the old eval treated a row-1 threat and a row-5 threat as equally valuable, which is just strategically wrong.

### Difficulty wiring

| Mode   | Old              | New |
| ------ | ---------------- | --- |
| easy   | heuristic only   | unchanged (heuristic only) |
| medium | depth 4, 30% / 25-point sandbag window | depth 7 with 800ms budget, 18% / 8-point window |
| hard   | depth 7          | unbounded depth (fully solves late-game) with 2500ms budget |

Sandbagging window tightened because deeper search produces finer-grained scores — the old 25-point gap that used to mean "essentially identical" now means "noticeably worse".

### Verification

External smoke harness (`tsc -p` to a temp dir + a Node script — not committed):

- Empty board → hard plays center (col 3).
- 3-in-a-row by opponent → hard blocks correctly in <1ms.
- 3-in-a-row by AI → hard wins correctly in <1ms.
- Hard vs medium over 5 games → hard wins 4-5/5.
- Medium vs easy → medium wins decisively.
- Late-game (few empty cells) → hard fully solves in <1ms.

`tsc -b`, `eslint .`, and `vite build` all pass.

### UX note

Hard's 2500ms budget means a single CPU turn can freeze the UI for up to ~2.5s while negamax runs synchronously (no Web Worker). The "CPU thinking…" pulse pauses during that window because the rAF loop is blocked. This was an explicit trade-off — the alternative is shipping a weaker hard mode. The 350ms `AI_THINK_MIN_MS` floor in `App.tsx` becomes a no-op on hard since the search itself almost always exceeds it.

https://claude.ai/code/session_014UYiKTg6kLnBUm3LRCLWmE

---
_Generated by [Claude Code](https://claude.ai/code/session_014UYiKTg6kLnBUm3LRCLWmE)_