### PR TITLE
Run AI in a Web Worker; refresh README architecture section

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,9 +37,9 @@ A from-scratch Connect 4 rendered entirely on an HTML5 canvas, with a **bitboard
 
 | Mode | Behavior |
 |------|----------|
-| **Easy** | Heuristic only — always blocks an immediate loss, always takes an immediate win, otherwise weighted-random with a center bias. Plays like a casual human. |
-| **Medium** | Depth-4 negamax with α-β. Occasionally picks the 2nd-best move when the gap is small so it doesn't feel mechanical. |
-| **Hard** | Depth-7 negamax with α-β + center-out move ordering. Spots traps several moves out and rarely walks into one. |
+| **Easy** | Heuristic only — always blocks an immediate loss, always takes an immediate win, otherwise weighted-random with a center bias. Plays like a casual human. Runs in-process. |
+| **Medium** | Depth-7 iterative-deepening negamax with α-β + transposition table + killer-move heuristic. ~800ms budget. Occasionally picks the 2nd-best move when the gap is genuinely small, so it doesn't feel mechanical. Runs in a Web Worker. |
+| **Hard** | Same engine, uncapped depth (up to MAX_MOVES) with a ~2.5s budget. Iteratively deepens within the budget; positions with few moves remaining are **fully solved** — the score is the true game-theoretic value. Heuristic understands Connect 4's parity / zugzwang principle. Runs in a Web Worker. |
 
 **Attract self-play** &mdash; Two easy-difficulty bots play each other behind the welcome modal as ambient motion, pausing on each result to let the win pulse play before resetting.
 
@@ -51,34 +51,47 @@ A from-scratch Connect 4 rendered entirely on an HTML5 canvas, with a **bitboard
 
 ## How It Works
 
-The AI runs a classic two-player game search on a bitboard representation of the position:
+The AI runs a classic two-player game search on a bitboard representation of the position. Medium and hard run inside a Web Worker so the UI keeps animating during multi-second searches; easy bypasses the worker (microseconds — round-trip would dominate).
 
 ```
 Board ──► fromGameBoard() — 49-bit Pascal-Pons encoding
               │
               ▼
-       Negamax search (depth depends on difficulty)
+       chooseMoveAsync() — main thread, returns Promise<col>
               │
               ▼
-       At each node:
-       ├── α-β pruning with center-out move ordering
+       Web Worker (medium / hard only)
+              │
+              ▼
+       Iterative deepening (depth 1, 2, … until budget or full solve)
+       └── Each pass seeds the next pass's move ordering via the TT
+              │
+              ▼
+       Negamax + α-β at each ply
+       ├── Transposition table (canonical 98-bit key: position | mask << 49n)
+       ├── Move ordering: TT-best → killer moves → center-out static
        ├── Immediate-win shortcut (mate-soon score)
        └── Recurse into legal children
               │
               ▼
        Leaf nodes: evaluatePosition() heuristic
        ├── 69 precomputed winning-line bitmasks
-       ├── Threat weights (3-in-a-row = 50, 2 = 10, 1 = 1)
+       ├── Threat density (3-in-a-row = 50, 2 = 10, 1 = 1)
+       ├── Parity-aware threat overlay — favored row +30, off-parity +6
+       │     (Connect 4's zugzwang rule: first player wants threats on odd
+       │      rows from the bottom; second player wants even rows)
        └── Center-column bonus
               │
               ▼
        Difficulty wrapper
-       ├── Easy   → no search; heuristic + weighted random
-       ├── Medium → depth-4 search; 30% chance of near-best move
-       └── Hard   → depth-7 search; no sandbagging
+       ├── Easy   → no search; heuristic + weighted random; in-process
+       ├── Medium → depth-7 cap, 800ms budget; tighter sandbagging
+       └── Hard   → unbounded depth, 2.5s budget; fully solves late game
 ```
 
 All move generation, win detection, and evaluation happen on BigInt bitboards (49 bits = 7 columns &times; (6 rows + 1 sentinel)), so winning-line checks are four shift-and-AND operations rather than a quadruple loop.
+
+**Worker cancellation.** When the player resets mid-search, the only reliable way to interrupt a synchronous `negamax` loop in a worker is `worker.terminate()` — web workers are single-threaded, so a `cancel` postMessage can't fire while the search is running, and SharedArrayBuffer (which would let the main thread set an abort flag via Atomics) needs COOP/COEP HTTP headers that GitHub Pages can't set. The client terminates and respawns; the in-flight promise is orphaned and GC'd, and the existing AI generation counter discards the result if it ever did arrive. Worker creation is ~10ms on respawn — invisible against the AI's minimum-think-time floor.
 
 The renderer is a pure-canvas paint loop driven by `requestAnimationFrame`. Layers composite in order:
 
@@ -125,9 +138,11 @@ src/
 │
 ├── ai/
 │   ├── bitboard.ts              49-bit Pascal-Pons encoding + primitives
-│   ├── eval.ts                  69-line heuristic with center-column bonus
-│   ├── search.ts                Negamax + α-β with center-out move ordering
+│   ├── eval.ts                  Threat-density heuristic with parity overlay
+│   ├── search.ts                Negamax + α-β + TT + iterative deepening
 │   ├── engine.ts                Difficulty profiles (easy / medium / hard)
+│   ├── worker.ts                Web Worker entry: runs negamax off-main-thread
+│   ├── engineClient.ts          Main-thread async client; terminate-to-cancel
 │   └── attractDemo.ts           Self-playing demo behind the welcome modal
 │
 ├── canvas/

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,7 +11,7 @@ import {
 } from './canvas/animations';
 import { paint, paintAttract } from './canvas/scene';
 import { setupInputs } from './canvas/input';
-import { chooseMove } from './ai/engine';
+import { cancelChooseMove, chooseMoveAsync } from './ai/engineClient';
 import { createAttract, resetAttract, stepAttract } from './ai/attractDemo';
 import { GithubAttribution } from './components/GithubAttribution';
 import { KeyboardHintsToggle } from './components/KeyboardHintsToggle';
@@ -26,11 +26,16 @@ const firstFreeRow = (column: ReadonlyArray<number>): number => {
 };
 
 /**
- * Minimum time the AI's move is held back. Two reasons:
- *   1. Without it, hard-difficulty moves look like a vending machine —
- *      instant responses break the illusion of "thinking".
+ * Minimum on-screen time for the "CPU thinking…" pulse. Two reasons:
+ *   1. Easy mode and immediate tactical wins resolve in microseconds —
+ *      without a floor they look like a vending machine, breaking the
+ *      illusion of deliberation.
  *   2. It also gives our setupInputs gate (which checks aiThinking) time
  *      to register, preventing rare race conditions if the user double-taps.
+ *
+ * Hard-mode searches now run in a worker (see ai/engineClient.ts), so the
+ * search itself almost always exceeds this floor and the floor becomes a
+ * no-op for those turns.
  */
 const AI_THINK_MIN_MS = 350;
 
@@ -227,22 +232,28 @@ const App = () => {
 
     // ── AI turn driver ──
     //
-    // Every relevant store update is examined: if it's now the AI's turn and
-    // we're not already mid-think, we schedule a move on a short timeout so
-    // it feels deliberate and the "thinking" indicator gets a frame to show.
+    // On the AI's turn we kick off chooseMoveAsync (which off-loads negamax to
+    // a Web Worker so the UI stays responsive during hard mode's multi-second
+    // burns) and start a parallel AI_THINK_MIN_MS minimum-delay timer. The
+    // move is committed once both have completed.
     //
-    // Cancellation: a pending timer is cleared whenever the precondition stops
-    // holding (player reset, game ended, returned to setup). A generation
-    // counter guards against the rare case where the timer's callback fires
-    // *just* after the game state changes but before our subscriber clears
-    // the timer.
-    let pendingAiTimer: number | null = null;
+    // Cancellation: bumping aiGeneration causes the resolved-search callback
+    // to bail via the staleness check; cancelChooseMove() terminates the
+    // worker so it stops burning CPU; pendingMinDelayTimer is cleared so a
+    // stale "place" callback can't fire after the user has reset the game.
+    // The orphaned promise (from the in-flight chooseMoveAsync) never
+    // resolves — that's intentional and safe; nothing references it after we
+    // discard it, so the closure is GC'd.
+    let pendingMinDelayTimer: number | null = null;
     let aiGeneration = 0;
 
     const cancelPendingAi = () => {
-      if (pendingAiTimer !== null) {
-        window.clearTimeout(pendingAiTimer);
-        pendingAiTimer = null;
+      // Bumping the generation discards any in-flight .then() callback.
+      ++aiGeneration;
+      cancelChooseMove();
+      if (pendingMinDelayTimer !== null) {
+        window.clearTimeout(pendingMinDelayTimer);
+        pendingMinDelayTimer = null;
       }
       // Drop the "thinking" flag too — leaving it set would keep the
       // "CPU thinking…" indicator on screen indefinitely.
@@ -264,27 +275,48 @@ const App = () => {
     const scheduleAiMove = () => {
       const state = useGameStore.getState();
       if (!shouldAiPlay(state)) return;
-      if (state.aiThinking || pendingAiTimer !== null) return;
+      // aiThinking gates re-entry — the existing turn is still resolving.
+      if (state.aiThinking) return;
 
       const myGen = ++aiGeneration;
       state.setAiThinking(true);
+      const startedAt = performance.now();
 
-      pendingAiTimer = window.setTimeout(() => {
-        pendingAiTimer = null;
-        const s = useGameStore.getState();
-        // Stale generation? The game state changed during the wait — abandon.
-        if (myGen !== aiGeneration || !shouldAiPlay(s)) {
-          if (s.aiThinking) s.setAiThinking(false);
-          return;
+      void chooseMoveAsync(
+        state.gameBoard,
+        state.currentPlayer,
+        state.difficulty,
+      ).then((col) => {
+        if (myGen !== aiGeneration) return; // cancelled or superseded mid-search
+
+        const place = () => {
+          pendingMinDelayTimer = null;
+          if (myGen !== aiGeneration) return;
+          const s = useGameStore.getState();
+          if (!shouldAiPlay(s)) {
+            if (s.aiThinking) s.setAiThinking(false);
+            return;
+          }
+          const row = firstFreeRow(s.gameBoard[col]);
+          if (row < 0) {
+            s.setAiThinking(false);
+            return;
+          }
+          s.addPiece(row, col);
+        };
+
+        // Hold the move until AI_THINK_MIN_MS has elapsed since the search
+        // started, so the pulsing "CPU thinking…" indicator gets at least
+        // one full beat on screen even when the search returned in
+        // milliseconds (easy bypass, immediate tactical wins, etc.).
+        const elapsed = performance.now() - startedAt;
+        const remaining = AI_THINK_MIN_MS - elapsed;
+        if (remaining > 0) {
+          pendingMinDelayTimer = window.setTimeout(place, remaining);
+        } else {
+          place();
         }
-        const col = chooseMove(s.gameBoard, s.currentPlayer, s.difficulty);
-        const row = firstFreeRow(s.gameBoard[col]);
-        if (row < 0) {
-          s.setAiThinking(false);
-          return;
-        }
-        s.addPiece(row, col);
-      }, AI_THINK_MIN_MS);
+      });
     };
 
     const unsubscribeAi = useGameStore.subscribe((state) => {

--- a/src/ai/engineClient.ts
+++ b/src/ai/engineClient.ts
@@ -1,0 +1,101 @@
+import { chooseMove } from './engine';
+import type { WorkerRequest, WorkerResponse } from './worker';
+import type { Difficulty, GameBoard, Player } from '../constants';
+
+/**
+ * Main-thread client for the AI worker. Exposes a single async API,
+ * `chooseMoveAsync`, that off-loads negamax to a Web Worker so the UI stays
+ * responsive during hard mode's multi-second searches.
+ *
+ * Lifecycle
+ * ---------
+ * The worker is created lazily on the first medium/hard call and kept alive
+ * across moves — repeated postMessages avoid the ~10-50ms module-load cost
+ * that fresh workers pay. On `cancelChooseMove`, we terminate and discard:
+ * web workers can't be interrupted by inbound messages while running a
+ * synchronous loop (no SharedArrayBuffer means no Atomics signal from the
+ * main thread), so terminate is the only reliable abort. The next
+ * chooseMoveAsync call respawns automatically.
+ *
+ * Cancellation contract
+ * ---------------------
+ * Cancelled promises NEVER resolve. Callers must guard against stale work
+ * with their own freshness check (the existing aiGeneration counter in
+ * App.tsx does exactly this) and treat the eventual-resolution contract as
+ * "may never resolve". Orphan promise closures are GC'd once nothing
+ * references them, so this doesn't leak.
+ *
+ * Easy difficulty bypasses the worker — it's heuristic-only and runs in
+ * microseconds. The round-trip postMessage would dwarf the actual work.
+ */
+
+let worker: Worker | null = null;
+let nextRequestId = 1;
+let pending: { id: number; resolve: (col: number) => void } | null = null;
+
+const ensureWorker = (): Worker => {
+  if (worker !== null) return worker;
+  // Vite recognises this exact `new URL` + `import.meta.url` idiom and
+  // bundles ./worker.ts as a separate worker chunk; no plugin or config
+  // needed. `type: 'module'` keeps ESM imports working inside the worker.
+  worker = new Worker(new URL('./worker.ts', import.meta.url), {
+    type: 'module',
+  });
+  worker.onmessage = (event: MessageEvent<WorkerResponse>) => {
+    if (pending === null || pending.id !== event.data.id) return;
+    const { resolve } = pending;
+    pending = null;
+    resolve(event.data.col);
+  };
+  return worker;
+};
+
+/**
+ * Run `chooseMove` off the main thread. Returns the AI's chosen column.
+ *
+ * Concurrency: only one request is in flight at a time. If a previous call
+ * is still pending when a new one comes in, the previous request is
+ * cancelled (worker terminated and respawned) and its promise is orphaned.
+ * The current AI scheduler in App.tsx never overlaps requests, so this is
+ * a defence-in-depth rather than an everyday code path.
+ */
+export const chooseMoveAsync = (
+  board: GameBoard,
+  currentPlayer: Player,
+  difficulty: Difficulty,
+): Promise<number> => {
+  // Easy is heuristic-only and runs in microseconds; bypass the worker
+  // entirely so the attract demo and PvE-easy don't pay round-trip latency.
+  if (difficulty === 'easy') {
+    return Promise.resolve(chooseMove(board, currentPlayer, difficulty));
+  }
+
+  if (pending !== null) cancelChooseMove();
+  const w = ensureWorker();
+  const id = nextRequestId++;
+  return new Promise<number>((resolve) => {
+    pending = { id, resolve };
+    const req: WorkerRequest = {
+      type: 'choose',
+      id,
+      board,
+      currentPlayer,
+      difficulty,
+    };
+    w.postMessage(req);
+  });
+};
+
+/**
+ * Abort the in-flight search, if any. The promise returned by the
+ * outstanding `chooseMoveAsync` call will never resolve — callers MUST
+ * guard with a generation counter or similar staleness check. The next
+ * `chooseMoveAsync` call respawns the worker.
+ */
+export const cancelChooseMove = (): void => {
+  if (worker !== null) {
+    worker.terminate();
+    worker = null;
+  }
+  pending = null;
+};

--- a/src/ai/worker.ts
+++ b/src/ai/worker.ts
@@ -1,0 +1,41 @@
+/// <reference lib="WebWorker" />
+
+/**
+ * Web-worker entry point for the AI engine. Receives `choose` requests on the
+ * main thread, runs the (synchronous) negamax search off-thread, and posts
+ * back the chosen column. Keeps the UI responsive — the rAF loop, drop
+ * animations, and CPU-thinking pulse all keep ticking while hard mode burns
+ * its 2.5s search budget.
+ *
+ * Cancellation
+ * ------------
+ * Web workers are single-threaded: an inbound `cancel` message can't fire
+ * while a synchronous `negamax` loop is mid-execution. The only reliable
+ * abort is `worker.terminate()` from the main thread (see engineClient.ts).
+ * That's why this worker exposes only one operation; respawn-on-cancel keeps
+ * the contract dead simple and the worker stateless.
+ */
+
+import { chooseMove } from './engine';
+import type { Difficulty, GameBoard, Player } from '../constants';
+
+export type WorkerRequest = {
+  type: 'choose';
+  id: number;
+  board: GameBoard;
+  currentPlayer: Player;
+  difficulty: Difficulty;
+};
+
+export type WorkerResponse = {
+  type: 'result';
+  id: number;
+  col: number;
+};
+
+self.onmessage = (event: MessageEvent<WorkerRequest>) => {
+  const { id, board, currentPlayer, difficulty } = event.data;
+  const col = chooseMove(board, currentPlayer, difficulty);
+  const response: WorkerResponse = { type: 'result', id, col };
+  (self as DedicatedWorkerGlobalScope).postMessage(response);
+};


### PR DESCRIPTION
Hard mode's 2.5s search budget was freezing the UI mid-think — the rAF loop, drop animations, and the pulsing "CPU thinking…" indicator all stalled because `chooseMove` ran synchronously on the main thread. This PR moves medium/hard searches off-thread so the UI keeps animating throughout.

### Architecture

- **`src/ai/worker.ts`** — `onmessage` handler that dispatches `chooseMove` and posts back the result. Vite's standard `new URL('./worker.ts', import.meta.url)` idiom emits it as a separate ~4kB chunk; no plugin or config needed.
- **`src/ai/engineClient.ts`** — main-thread `chooseMoveAsync(board, player, difficulty)` returning `Promise<number>`. Lazily spawns one worker, reuses it across moves (no per-call ~10ms module-load cost), and exposes `cancelChooseMove()` for resets.
- **`src/App.tsx`** — AI scheduler converted to the async client. `AI_THINK_MIN_MS` becomes a parallel min-delay timer rather than a leading `setTimeout`, so the search starts immediately but the move is held back until both the search and the floor have completed.

Easy difficulty bypasses the worker entirely — heuristic-only, runs in microseconds, postMessage round-trip would dominate. The attract demo (also easy) keeps using the synchronous `chooseMove` directly.

### Cancellation

Web workers are single-threaded, so a `cancel` postMessage can't fire while a synchronous `negamax` loop is mid-execution — the message handler doesn't get a turn until the search yields back to the event loop, and the synchronous search never does. SharedArrayBuffer + Atomics would let the main thread set an abort flag the worker could observe in its periodic deadline check, but SharedArrayBuffer requires COOP/COEP HTTP headers that GitHub Pages can't set.

So cancellation = `worker.terminate()` + respawn-on-next-call. ~10ms cost, invisible against the existing `AI_THINK_MIN_MS` floor. The orphaned promise never resolves; callers (just the AI scheduler in App.tsx) guard with the existing `aiGeneration` counter and discard any stale result. The orphan closure is GC'd once nothing references the promise.

### What changed for users

- The "CPU thinking…" indicator now actually pulses during hard's deep search — previously it froze on a static frame.
- Drop animations from the previous move can finish smoothly while the AI computes its reply.
- Reset / "return to setup" feels instant even mid-search instead of waiting for the search to finish.

### README refresh

While here, the README's Features table, architecture diagram, and project-structure listing were stale (still described depth-4/depth-7 negamax, no TT, no iterative deepening, no parity eval). Updated all three to reflect the current AI architecture, plus added a "Worker cancellation" paragraph explaining the terminate-on-cancel trade-off.

### Verification

- `tsc -b`, `eslint .`, `vite build` all pass.
- Vite emits `dist/assets/worker-*.js` (~4kB) as a separate chunk — confirmed via build output.
- Underlying engine unchanged: re-ran the smoke harness from the previous PR (`hard wins ~3-5/5 vs medium`); behaviour matches.
- Worker behaviour itself can't be exercised in this CI (no browser DOM/Worker API), but the client/worker contract is small and the message protocol is one type each direction.

https://claude.ai/code/session_014UYiKTg6kLnBUm3LRCLWmE

---
_Generated by [Claude Code](https://claude.ai/code/session_014UYiKTg6kLnBUm3LRCLWmE)_